### PR TITLE
Enable Envoy sidecars graceful shutdown

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL:=/bin/bash
 # Current Operator version
-VERSION ?= 0.9.6
+VERSION ?= 0.9.7
 # Default catalog image
 CATALOG_IMG ?= quay.io/3scaleops/saas-operator-bundle:catalog
 # Default bundle image tag

--- a/bundle/manifests/saas-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/saas-operator.clusterserviceversion.yaml
@@ -585,7 +585,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/3scale/saas-operator
     support: Red Hat
-  name: saas-operator.v0.9.6
+  name: saas-operator.v0.9.7
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -3038,7 +3038,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
-                image: quay.io/3scale/saas-operator:0.9.6
+                image: quay.io/3scale/saas-operator:0.9.7
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -3425,4 +3425,4 @@ spec:
   provider:
     name: Red Hat
     url: https://www.3scale.net/
-  version: 0.9.6
+  version: 0.9.7

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,4 +13,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/3scale/saas-operator
-  newTag: 0.9.6
+  newTag: 0.9.7

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -99,7 +99,7 @@ func dashboardsApicastServicesJsonTpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "dashboards/apicast-services.json.tpl", size: 17460, mode: os.FileMode(436), modTime: time.Unix(1614781994, 0)}
+	info := bindataFileInfo{name: "dashboards/apicast-services.json.tpl", size: 17460, mode: os.FileMode(420), modTime: time.Unix(1614940003, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -119,7 +119,7 @@ func dashboardsApicastJsonTpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "dashboards/apicast.json.tpl", size: 84544, mode: os.FileMode(436), modTime: time.Unix(1614781994, 0)}
+	info := bindataFileInfo{name: "dashboards/apicast.json.tpl", size: 84544, mode: os.FileMode(420), modTime: time.Unix(1614940003, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -139,7 +139,7 @@ func dashboardsAutosslJsonTpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "dashboards/autossl.json.tpl", size: 59358, mode: os.FileMode(436), modTime: time.Unix(1614781994, 0)}
+	info := bindataFileInfo{name: "dashboards/autossl.json.tpl", size: 59358, mode: os.FileMode(420), modTime: time.Unix(1614940003, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -159,7 +159,7 @@ func dashboardsBackendJsonTpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "dashboards/backend.json.tpl", size: 138352, mode: os.FileMode(436), modTime: time.Unix(1614781994, 0)}
+	info := bindataFileInfo{name: "dashboards/backend.json.tpl", size: 138352, mode: os.FileMode(420), modTime: time.Unix(1614940003, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -179,7 +179,7 @@ func dashboardsCorsProxyJsonTpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "dashboards/cors-proxy.json.tpl", size: 78729, mode: os.FileMode(436), modTime: time.Unix(1614781994, 0)}
+	info := bindataFileInfo{name: "dashboards/cors-proxy.json.tpl", size: 78729, mode: os.FileMode(420), modTime: time.Unix(1614940003, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -199,7 +199,7 @@ func dashboardsMappingServiceJsonTpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "dashboards/mapping-service.json.tpl", size: 70520, mode: os.FileMode(436), modTime: time.Unix(1614781994, 0)}
+	info := bindataFileInfo{name: "dashboards/mapping-service.json.tpl", size: 70520, mode: os.FileMode(420), modTime: time.Unix(1614940003, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -219,7 +219,7 @@ func dashboardsSystemJsonTpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "dashboards/system.json.tpl", size: 81336, mode: os.FileMode(436), modTime: time.Unix(1614782981, 0)}
+	info := bindataFileInfo{name: "dashboards/system.json.tpl", size: 81336, mode: os.FileMode(420), modTime: time.Unix(1614940003, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -239,7 +239,7 @@ func dashboardsZyncJsonTpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "dashboards/zync.json.tpl", size: 70336, mode: os.FileMode(436), modTime: time.Unix(1614781994, 0)}
+	info := bindataFileInfo{name: "dashboards/zync.json.tpl", size: 70336, mode: os.FileMode(420), modTime: time.Unix(1614940003, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/pkg/generators/common_blocks/marin3r/util.go
+++ b/pkg/generators/common_blocks/marin3r/util.go
@@ -14,6 +14,12 @@ const (
 	sidecarEnabledLabelValue string = "enabled"
 )
 
+var (
+	defaultAnnotations map[string]string = map[string]string{
+		"marin3r.3scale.net/shutdown-manager.enabled": "true",
+	}
+)
+
 // EnableSidecar adds the apporopriates labels and annotations for marin3r sidecar
 // injection to work for this Deployment
 func EnableSidecar(dep appsv1.Deployment, spec saasv1alpha1.Marin3rSidecarSpec) *appsv1.Deployment {
@@ -29,6 +35,7 @@ func EnableSidecar(dep appsv1.Deployment, spec saasv1alpha1.Marin3rSidecarSpec) 
 		dep.Spec.Template.ObjectMeta.Annotations,
 		resourcesAnnotations(spec.Resources),
 		portsAnnotation(spec.Ports),
+		defaultAnnotations,
 		spec.ExtraPodAnnotations,
 	)
 

--- a/pkg/generators/common_blocks/marin3r/util_test.go
+++ b/pkg/generators/common_blocks/marin3r/util_test.go
@@ -63,7 +63,8 @@ func TestEnableSidecar(t *testing.T) {
 								"marin3r.3scale.net/resources.requests.cpu":    "100m",
 								"marin3r.3scale.net/resources.requests.memory": "100Mi",
 								"marin3r.3scale.net/ports":                     "test:9999",
-								"extra-key":                                    "extra-value",
+								"marin3r.3scale.net/shutdown-manager.enabled":  "true",
+								"extra-key": "extra-value",
 							},
 							Labels: map[string]string{
 								"marin3r.3scale.net/status": "enabled",

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,7 +1,7 @@
 package version
 
 const (
-	version string = "v0.9.6"
+	version string = "v0.9.7"
 )
 
 // Current returns the current marin3r operator version


### PR DESCRIPTION
Adds the annotation required to all Pods using Envoy sidecars so graceful shutdown of the Envoy server is enabled.

/kind feature
/priority important-soon
/assign