### PR TITLE
fix/operator-resources

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL:=/bin/bash
 # Current Operator version
-VERSION ?= 0.9.7
+VERSION ?= 0.9.8
 # Default catalog image
 CATALOG_IMG ?= quay.io/3scaleops/saas-operator-bundle:catalog
 # Default bundle image tag

--- a/bundle/manifests/saas-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/saas-operator.clusterserviceversion.yaml
@@ -585,7 +585,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/3scale/saas-operator
     support: Red Hat
-  name: saas-operator.v0.9.7
+  name: saas-operator.v0.9.8
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -3038,7 +3038,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
-                image: quay.io/3scale/saas-operator:0.9.7
+                image: quay.io/3scale/saas-operator:0.9.8
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -3054,11 +3054,11 @@ spec:
                   periodSeconds: 10
                 resources:
                   limits:
-                    cpu: 100m
-                    memory: 30Mi
+                    cpu: 50m
+                    memory: 700Mi
                   requests:
-                    cpu: 100m
-                    memory: 20Mi
+                    cpu: 25m
+                    memory: 200Mi
                 securityContext:
                   allowPrivilegeEscalation: false
               serviceAccountName: saas-operator-controller-manager
@@ -3425,4 +3425,4 @@ spec:
   provider:
     name: Red Hat
     url: https://www.3scale.net/
-  version: 0.9.7
+  version: 0.9.8

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,4 +13,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/3scale/saas-operator
-  newTag: 0.9.7
+  newTag: 0.9.8

--- a/config/manager/manager.yaml
+++ b/config/manager/manager.yaml
@@ -52,11 +52,11 @@ spec:
           periodSeconds: 10
         resources:
           limits:
-            cpu: 100m
-            memory: 30Mi
+            cpu: 50m
+            memory: 700Mi
           requests:
-            cpu: 100m
-            memory: 20Mi
+            cpu: 25m
+            memory: 200Mi
       terminationGracePeriodSeconds: 10
 
 ---

--- a/pkg/basereconciler/reconcile_resources.go
+++ b/pkg/basereconciler/reconcile_resources.go
@@ -264,7 +264,7 @@ func (r *Reconciler) ReconcileOwnedResources(ctx context.Context, owner client.O
 func ServiceExcludes(fn GeneratorFunction) []string {
 	svc := fn().(*corev1.Service)
 	paths := []string{}
-	paths = append(paths, "/spec/clusterIP")
+	paths = append(paths, "/spec/clusterIP", "/spec/clusterIPs")
 	for idx := range svc.Spec.Ports {
 		paths = append(paths, fmt.Sprintf("/spec/ports/%d/nodePort", idx))
 	}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,7 +1,7 @@
 package version
 
 const (
-	version string = "v0.9.7"
+	version string = "v0.9.8"
 )
 
 // Current returns the current marin3r operator version


### PR DESCRIPTION
The operator has a big surge in memory consumption when it starts, probably due to the fact that starts all reconcile workers for all the resources at the same time and starts checking that everything is in the desired state, which involves a lot of events for a lot of resources. After this it memory consumption stabilizes at around 200M.

The PR also fixes a problem with a new calculated field in the spec of services that the operator was trying to reconcile in an infinite loop.

/priority critical-urgent
/kind bug
/assign