### PR TITLE
feat: add system app init container

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL:=/bin/bash
 # Current Operator version
-VERSION ?= 0.9.8
+VERSION ?= 0.9.9
 # Default catalog image
 CATALOG_IMG ?= quay.io/3scaleops/saas-operator-bundle:catalog
 # Default bundle image tag

--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,9 @@ endif
 ifeq ($(shell arch),aarch64)
 ARCH := arm64
 endif
+ifeq ($(shell uname -m),x86_64)
+ARCH := amd64
+endif
 
 # Download operator-sdk binary if necesasry
 OPERATOR_SDK_RELEASE = v1.3.2

--- a/bundle/manifests/saas-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/saas-operator.clusterserviceversion.yaml
@@ -585,7 +585,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/3scale/saas-operator
     support: Red Hat
-  name: saas-operator.v0.9.8
+  name: saas-operator.v0.9.9
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -3038,7 +3038,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
-                image: quay.io/3scale/saas-operator:0.9.8
+                image: quay.io/3scale/saas-operator:0.9.9
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -3425,4 +3425,4 @@ spec:
   provider:
     name: Red Hat
     url: https://www.3scale.net/
-  version: 0.9.8
+  version: 0.9.9

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,4 +13,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/3scale/saas-operator
-  newTag: 0.9.8
+  newTag: 0.9.9

--- a/pkg/generators/system/app_deployment.go
+++ b/pkg/generators/system/app_deployment.go
@@ -51,6 +51,19 @@ func (gen *AppGenerator) Deployment() basereconciler.GeneratorFunction {
 							}
 							return nil
 						}(),
+						InitContainers: []corev1.Container{
+							{
+								Name:  fmt.Sprintf("%s-k8s-deploy", gen.GetComponent()),
+								Image: fmt.Sprintf("%s:%s", *gen.ImageSpec.Name, *gen.ImageSpec.Tag),
+								Args: []string{
+									"bundle", "exec", "rake", "k8s:deploy",
+								},
+								Env:                      pod.BuildEnvironment(gen.Options),
+								ImagePullPolicy:          *gen.ImageSpec.PullPolicy,
+								TerminationMessagePath:   corev1.TerminationMessagePathDefault,
+								TerminationMessagePolicy: corev1.TerminationMessageReadFile,
+							},
+						},
 						Containers: []corev1.Container{
 							{
 								Name:  gen.GetComponent(),

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,7 +1,7 @@
 package version
 
 const (
-	version string = "v0.9.8"
+	version string = "v0.9.9"
 )
 
 // Current returns the current marin3r operator version


### PR DESCRIPTION
Adds the `system-app-k8s-deploy` init container that will enqueue some tasks to the sidekiq workers that are required to be scheduled before staring a `system-app` pod.

/kind feature
/priority important-soon
/assign