### PR TITLE
Add documentation about the operator release process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -195,7 +195,7 @@ tmp:
 
 prepare-alpha-release: bump-release generate fmt vet manifests bundle
 
-prepare-release: bump-release generate fmt vet manifests bundle
+prepare-stable-release: bump-release generate fmt vet manifests bundle
 	$(MAKE) bundle CHANNELS=alpha,stable DEFAULT_CHANNEL=alpha
 
 bump-release:

--- a/docs/release.md
+++ b/docs/release.md
@@ -1,1 +1,19 @@
-TODO
+# Release
+
+* Update Makefile variable `VERSION` to the appropiate release version. Allowed formats:
+  * alpha: `VERSION ?= 0.3.0-alpha.12`
+  * stable: `VERSION ?= 0.3.0`
+
+## Alpha
+* If it is an **alpha** release, execute the following target to create appropiate `alpha` bundle files:
+```bash
+make prepare-alpha-release
+```
+* Then you can manually execute opeator, bundle and catalog build/push.
+
+## Stable
+* But if it is an **stable** release, execute the following target to create appropiate `alpha` and `stable` bundle files:
+```bash
+make prepare-stable-release
+```
+* Then open a [Pull Request](https://github.com/3scale-ops/saas-operator/pulls), and a GitHub Action will automatically detect if it is new release or not, in order to create it by building/pushing new operator, bundle and catalog images, as well as creating a GitHub release draft.


### PR DESCRIPTION
- Added documentation about release process of stable/alpha releases
- To avoid accidental stable releases creation when you want to do an alpha release, the prepare stable  target has been renamed
- Docs taken from [prometheus-exporter-operator release doc](https://github.com/3scale-ops/prometheus-exporter-operator/blob/main/docs/prometheus-exporter-crd-reference.md), so right now all our 3 operators ([prometheus-exporter-operator](https://github.com/3scale-ops/prometheus-exporter-operator), [marin3r](https://github.com/3scale-ops/marin3r) and [saas-operator](https://github.com/3scale-ops/saas-operator) ) use the exactly same release process (easier maintenance using all of them the same).

/kind documentation
/priority important-soon
/assign