### PR TITLE
feat: rename apicast token name

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL:=/bin/bash
 # Current Operator version
-VERSION ?= 0.10.0
+VERSION ?= 0.10.1
 # Default catalog image
 CATALOG_IMG ?= quay.io/3scaleops/saas-operator-bundle:catalog
 # Default bundle image tag

--- a/api/v1alpha1/system_types.go
+++ b/api/v1alpha1/system_types.go
@@ -301,7 +301,7 @@ type SystemConfig struct {
 	SMTP SMTPSpec `json:"smtp"`
 	// Master access token for Apicast
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
-	ApicastAccessToken SecretReference `json:"apicastAccessToken"`
+	MappingServiceAccessToken SecretReference `json:"mappingServiceAccessToken"`
 	// Zync authentication token
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	ZyncAuthToken SecretReference `json:"zyncAuthToken"`

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -2023,7 +2023,7 @@ func (in *SystemConfig) DeepCopyInto(out *SystemConfig) {
 	in.DatabaseSecret.DeepCopyInto(&out.DatabaseSecret)
 	out.Redis = in.Redis
 	in.SMTP.DeepCopyInto(&out.SMTP)
-	in.ApicastAccessToken.DeepCopyInto(&out.ApicastAccessToken)
+	in.MappingServiceAccessToken.DeepCopyInto(&out.MappingServiceAccessToken)
 	in.ZyncAuthToken.DeepCopyInto(&out.ZyncAuthToken)
 	in.Backend.DeepCopyInto(&out.Backend)
 	in.Assets.DeepCopyInto(&out.Assets)

--- a/bundle/manifests/saas-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/saas-operator.clusterserviceversion.yaml
@@ -1970,21 +1970,6 @@ spec:
       - description: AMP release number
         displayName: AMPRelease
         path: config.ampRelease
-      - description: Master access token for Apicast
-        displayName: Apicast Access Token
-        path: config.apicastAccessToken
-      - description: VaultSecretReference is a reference to a secret stored in a Hashicorp Vault
-        displayName: From Vault
-        path: config.apicastAccessToken.fromVault
-      - description: The Vault key of the secret
-        displayName: Key
-        path: config.apicastAccessToken.fromVault.key
-      - description: The Vault path where the secret is located
-        displayName: Path
-        path: config.apicastAccessToken.fromVault.path
-      - description: Override allows to directly specify a string value.
-        displayName: Override
-        path: config.apicastAccessToken.override
       - description: AWS access key
         displayName: Access Key
         path: config.assets.accessKey
@@ -2165,6 +2150,21 @@ spec:
       - description: Override allows to directly specify a string value.
         displayName: Override
         path: config.github.clientSecret.override
+      - description: Master access token for Apicast
+        displayName: Mapping Service Access Token
+        path: config.mappingServiceAccessToken
+      - description: VaultSecretReference is a reference to a secret stored in a Hashicorp Vault
+        displayName: From Vault
+        path: config.mappingServiceAccessToken.fromVault
+      - description: The Vault key of the secret
+        displayName: Key
+        path: config.mappingServiceAccessToken.fromVault.key
+      - description: The Vault path where the secret is located
+        displayName: Path
+        path: config.mappingServiceAccessToken.fromVault.path
+      - description: Override allows to directly specify a string value.
+        displayName: Override
+        path: config.mappingServiceAccessToken.override
       - description: Memcached servers
         displayName: Memcached Servers
         path: config.memcachedServers

--- a/bundle/manifests/saas-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/saas-operator.clusterserviceversion.yaml
@@ -585,7 +585,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/3scale/saas-operator
     support: Red Hat
-  name: saas-operator.v0.10.0
+  name: saas-operator.v0.10.1
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -3038,7 +3038,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
-                image: quay.io/3scale/saas-operator:0.10.0
+                image: quay.io/3scale/saas-operator:0.10.1
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -3425,4 +3425,4 @@ spec:
   provider:
     name: Red Hat
     url: https://www.3scale.net/
-  version: 0.10.0
+  version: 0.10.1

--- a/bundle/manifests/saas.3scale.net_systems.yaml
+++ b/bundle/manifests/saas.3scale.net_systems.yaml
@@ -364,26 +364,6 @@ spec:
                   ampRelease:
                     description: AMP release number
                     type: string
-                  apicastAccessToken:
-                    description: Master access token for Apicast
-                    properties:
-                      fromVault:
-                        description: VaultSecretReference is a reference to a secret stored in a Hashicorp Vault
-                        properties:
-                          key:
-                            description: The Vault key of the secret
-                            type: string
-                          path:
-                            description: The Vault path where the secret is located
-                            type: string
-                        required:
-                        - key
-                        - path
-                        type: object
-                      override:
-                        description: Override allows to directly specify a string value.
-                        type: string
-                    type: object
                   assets:
                     description: Assets has configuration to access assets in AWS s3
                     properties:
@@ -646,6 +626,26 @@ spec:
                     required:
                     - clientID
                     - clientSecret
+                    type: object
+                  mappingServiceAccessToken:
+                    description: Master access token for Apicast
+                    properties:
+                      fromVault:
+                        description: VaultSecretReference is a reference to a secret stored in a Hashicorp Vault
+                        properties:
+                          key:
+                            description: The Vault key of the secret
+                            type: string
+                          path:
+                            description: The Vault path where the secret is located
+                            type: string
+                        required:
+                        - key
+                        - path
+                        type: object
+                      override:
+                        description: Override allows to directly specify a string value.
+                        type: string
                     type: object
                   memcachedServers:
                     description: Memcached servers
@@ -1137,13 +1137,13 @@ spec:
                     type: object
                 required:
                 - accessCode
-                - apicastAccessToken
                 - assets
                 - backend
                 - databaseDSN
                 - databaseSecret
                 - eventsSharedSecret
                 - github
+                - mappingServiceAccessToken
                 - memcachedServers
                 - metrics
                 - recaptcha

--- a/config/crd/bases/saas.3scale.net_systems.yaml
+++ b/config/crd/bases/saas.3scale.net_systems.yaml
@@ -511,28 +511,6 @@ spec:
                   ampRelease:
                     description: AMP release number
                     type: string
-                  apicastAccessToken:
-                    description: Master access token for Apicast
-                    properties:
-                      fromVault:
-                        description: VaultSecretReference is a reference to a secret
-                          stored in a Hashicorp Vault
-                        properties:
-                          key:
-                            description: The Vault key of the secret
-                            type: string
-                          path:
-                            description: The Vault path where the secret is located
-                            type: string
-                        required:
-                        - key
-                        - path
-                        type: object
-                      override:
-                        description: Override allows to directly specify a string
-                          value.
-                        type: string
-                    type: object
                   assets:
                     description: Assets has configuration to access assets in AWS
                       s3
@@ -817,6 +795,28 @@ spec:
                     required:
                     - clientID
                     - clientSecret
+                    type: object
+                  mappingServiceAccessToken:
+                    description: Master access token for Apicast
+                    properties:
+                      fromVault:
+                        description: VaultSecretReference is a reference to a secret
+                          stored in a Hashicorp Vault
+                        properties:
+                          key:
+                            description: The Vault key of the secret
+                            type: string
+                          path:
+                            description: The Vault path where the secret is located
+                            type: string
+                        required:
+                        - key
+                        - path
+                        type: object
+                      override:
+                        description: Override allows to directly specify a string
+                          value.
+                        type: string
                     type: object
                   memcachedServers:
                     description: Memcached servers
@@ -1345,13 +1345,13 @@ spec:
                     type: object
                 required:
                 - accessCode
-                - apicastAccessToken
                 - assets
                 - backend
                 - databaseDSN
                 - databaseSecret
                 - eventsSharedSecret
                 - github
+                - mappingServiceAccessToken
                 - memcachedServers
                 - metrics
                 - recaptcha

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,4 +13,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/3scale/saas-operator
-  newTag: 0.10.0
+  newTag: 0.10.1

--- a/config/manifests/bases/saas-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/saas-operator.clusterserviceversion.yaml
@@ -1528,21 +1528,6 @@ spec:
       - description: AMP release number
         displayName: AMPRelease
         path: config.ampRelease
-      - description: Master access token for Apicast
-        displayName: Apicast Access Token
-        path: config.apicastAccessToken
-      - description: VaultSecretReference is a reference to a secret stored in a Hashicorp Vault
-        displayName: From Vault
-        path: config.apicastAccessToken.fromVault
-      - description: The Vault key of the secret
-        displayName: Key
-        path: config.apicastAccessToken.fromVault.key
-      - description: The Vault path where the secret is located
-        displayName: Path
-        path: config.apicastAccessToken.fromVault.path
-      - description: Override allows to directly specify a string value.
-        displayName: Override
-        path: config.apicastAccessToken.override
       - description: AWS access key
         displayName: Access Key
         path: config.assets.accessKey
@@ -1723,6 +1708,21 @@ spec:
       - description: Override allows to directly specify a string value.
         displayName: Override
         path: config.github.clientSecret.override
+      - description: Master access token for Apicast
+        displayName: Mapping Service Access Token
+        path: config.mappingServiceAccessToken
+      - description: VaultSecretReference is a reference to a secret stored in a Hashicorp Vault
+        displayName: From Vault
+        path: config.mappingServiceAccessToken.fromVault
+      - description: The Vault key of the secret
+        displayName: Key
+        path: config.mappingServiceAccessToken.fromVault.key
+      - description: The Vault path where the secret is located
+        displayName: Path
+        path: config.mappingServiceAccessToken.fromVault.path
+      - description: Override allows to directly specify a string value.
+        displayName: Override
+        path: config.mappingServiceAccessToken.override
       - description: Memcached servers
         displayName: Memcached Servers
         path: config.memcachedServers

--- a/controllers/system_controller_suite_test.go
+++ b/controllers/system_controller_suite_test.go
@@ -112,8 +112,8 @@ var _ = Describe("System controller", func() {
 							OpenSSLVerifyMode: "value",
 							STARTTLSAuto:      false,
 						},
-						ApicastAccessToken: saasv1alpha1.SecretReference{Override: pointer.StringPtr("override")},
-						ZyncAuthToken:      saasv1alpha1.SecretReference{Override: pointer.StringPtr("override")},
+						MappingServiceAccessToken: saasv1alpha1.SecretReference{Override: pointer.StringPtr("override")},
+						ZyncAuthToken:             saasv1alpha1.SecretReference{Override: pointer.StringPtr("override")},
 						Backend: saasv1alpha1.SystemBackendSpec{
 							ExternalEndpoint:    "value",
 							InternalEndpoint:    "value",

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -99,7 +99,7 @@ func dashboardsApicastServicesJsonTpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "dashboards/apicast-services.json.tpl", size: 17460, mode: os.FileMode(420), modTime: time.Unix(1614940003, 0)}
+	info := bindataFileInfo{name: "dashboards/apicast-services.json.tpl", size: 17460, mode: os.FileMode(420), modTime: time.Unix(1615201850, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -119,7 +119,7 @@ func dashboardsApicastJsonTpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "dashboards/apicast.json.tpl", size: 84544, mode: os.FileMode(420), modTime: time.Unix(1614940003, 0)}
+	info := bindataFileInfo{name: "dashboards/apicast.json.tpl", size: 84544, mode: os.FileMode(420), modTime: time.Unix(1615201850, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -139,7 +139,7 @@ func dashboardsAutosslJsonTpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "dashboards/autossl.json.tpl", size: 59358, mode: os.FileMode(420), modTime: time.Unix(1614940003, 0)}
+	info := bindataFileInfo{name: "dashboards/autossl.json.tpl", size: 59358, mode: os.FileMode(420), modTime: time.Unix(1615201850, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -159,7 +159,7 @@ func dashboardsBackendJsonTpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "dashboards/backend.json.tpl", size: 138352, mode: os.FileMode(420), modTime: time.Unix(1614940003, 0)}
+	info := bindataFileInfo{name: "dashboards/backend.json.tpl", size: 138352, mode: os.FileMode(420), modTime: time.Unix(1615201850, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -179,7 +179,7 @@ func dashboardsCorsProxyJsonTpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "dashboards/cors-proxy.json.tpl", size: 78729, mode: os.FileMode(420), modTime: time.Unix(1614940003, 0)}
+	info := bindataFileInfo{name: "dashboards/cors-proxy.json.tpl", size: 78729, mode: os.FileMode(420), modTime: time.Unix(1615201850, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -199,7 +199,7 @@ func dashboardsMappingServiceJsonTpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "dashboards/mapping-service.json.tpl", size: 70520, mode: os.FileMode(420), modTime: time.Unix(1614940003, 0)}
+	info := bindataFileInfo{name: "dashboards/mapping-service.json.tpl", size: 70520, mode: os.FileMode(420), modTime: time.Unix(1615201850, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -219,7 +219,7 @@ func dashboardsSystemJsonTpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "dashboards/system.json.tpl", size: 81336, mode: os.FileMode(420), modTime: time.Unix(1614940003, 0)}
+	info := bindataFileInfo{name: "dashboards/system.json.tpl", size: 81336, mode: os.FileMode(420), modTime: time.Unix(1615201850, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -239,7 +239,7 @@ func dashboardsZyncJsonTpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "dashboards/zync.json.tpl", size: 70336, mode: os.FileMode(420), modTime: time.Unix(1614940003, 0)}
+	info := bindataFileInfo{name: "dashboards/zync.json.tpl", size: 70336, mode: os.FileMode(420), modTime: time.Unix(1615201850, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/pkg/generators/system/config/options.go
+++ b/pkg/generators/system/config/options.go
@@ -61,7 +61,7 @@ type Options struct {
 	SMTPOpensslVerifyMode pod.EnvVarValue `env:"SMTP_OPENSSL_VERIFY_MODE"`
 	SMTPSTARTTLSAuto      pod.EnvVarValue `env:"SMTP_STARTTLS_AUTO"`
 
-	ApicastAccessToken pod.EnvVarValue `env:"APICAST_ACCESS_TOKEN" secret:"system-master-apicast"`
+	MappingServiceAccessToken pod.EnvVarValue `env:"APICAST_ACCESS_TOKEN" secret:"system-master-apicast"`
 
 	ZyncAuthenticationToken pod.EnvVarValue `env:"ZYNC_AUTHENTICATION_TOKEN" secret:"system-zync"`
 
@@ -148,7 +148,7 @@ func NewOptions(spec saasv1alpha1.SystemSpec) Options {
 		SMTPOpensslVerifyMode: &pod.ClearTextValue{Value: spec.Config.SMTP.OpenSSLVerifyMode},
 		SMTPSTARTTLSAuto:      &pod.ClearTextValue{Value: fmt.Sprintf("%t", spec.Config.SMTP.STARTTLSAuto)},
 
-		ApicastAccessToken: &pod.SecretValue{Value: spec.Config.ApicastAccessToken},
+		MappingServiceAccessToken: &pod.SecretValue{Value: spec.Config.MappingServiceAccessToken},
 
 		ZyncAuthenticationToken: &pod.SecretValue{Value: spec.Config.ZyncAuthToken},
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,7 +1,7 @@
 package version
 
 const (
-	version string = "v0.10.0"
+	version string = "v0.10.1"
 )
 
 // Current returns the current marin3r operator version


### PR DESCRIPTION
Replaces system `apicastAccessToken` attribute with `mappingServiceAccessToken` to avoid confusion.

/kind cleanup
/priority important-soon
/assign
/hold