### PR TITLE
feat: provide a deprecation path for the apicastAccessToken

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL:=/bin/bash
 # Current Operator version
-VERSION ?= 0.10.1
+VERSION ?= 0.10.2
 # Default catalog image
 CATALOG_IMG ?= quay.io/3scaleops/saas-operator-bundle:catalog
 # Default bundle image tag

--- a/api/v1alpha1/system_types.go
+++ b/api/v1alpha1/system_types.go
@@ -299,9 +299,14 @@ type SystemConfig struct {
 	// SMTP configuration options
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	SMTP SMTPSpec `json:"smtp"`
+	// Mapping Service access token
+	// +operator-sdk:csv:customresourcedefinitions:type=spec
+	// +optional
+	MappingServiceAccessToken SecretReference `json:"mappingServiceAccessToken"`
 	// Master access token for Apicast
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
-	MappingServiceAccessToken SecretReference `json:"mappingServiceAccessToken"`
+	// +optional
+	ApicastAccessToken SecretReference `json:"apicastAccessToken"`
 	// Zync authentication token
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	ZyncAuthToken SecretReference `json:"zyncAuthToken"`

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -2024,6 +2024,7 @@ func (in *SystemConfig) DeepCopyInto(out *SystemConfig) {
 	out.Redis = in.Redis
 	in.SMTP.DeepCopyInto(&out.SMTP)
 	in.MappingServiceAccessToken.DeepCopyInto(&out.MappingServiceAccessToken)
+	in.ApicastAccessToken.DeepCopyInto(&out.ApicastAccessToken)
 	in.ZyncAuthToken.DeepCopyInto(&out.ZyncAuthToken)
 	in.Backend.DeepCopyInto(&out.Backend)
 	in.Assets.DeepCopyInto(&out.Assets)

--- a/bundle/manifests/saas-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/saas-operator.clusterserviceversion.yaml
@@ -585,7 +585,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/3scale/saas-operator
     support: Red Hat
-  name: saas-operator.v0.10.1
+  name: saas-operator.v0.10.2
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -1970,6 +1970,21 @@ spec:
       - description: AMP release number
         displayName: AMPRelease
         path: config.ampRelease
+      - description: Master access token for Apicast
+        displayName: Apicast Access Token
+        path: config.apicastAccessToken
+      - description: VaultSecretReference is a reference to a secret stored in a Hashicorp Vault
+        displayName: From Vault
+        path: config.apicastAccessToken.fromVault
+      - description: The Vault key of the secret
+        displayName: Key
+        path: config.apicastAccessToken.fromVault.key
+      - description: The Vault path where the secret is located
+        displayName: Path
+        path: config.apicastAccessToken.fromVault.path
+      - description: Override allows to directly specify a string value.
+        displayName: Override
+        path: config.apicastAccessToken.override
       - description: AWS access key
         displayName: Access Key
         path: config.assets.accessKey
@@ -2150,7 +2165,7 @@ spec:
       - description: Override allows to directly specify a string value.
         displayName: Override
         path: config.github.clientSecret.override
-      - description: Master access token for Apicast
+      - description: Mapping Service access token
         displayName: Mapping Service Access Token
         path: config.mappingServiceAccessToken
       - description: VaultSecretReference is a reference to a secret stored in a Hashicorp Vault
@@ -3038,7 +3053,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
-                image: quay.io/3scale/saas-operator:0.10.1
+                image: quay.io/3scale/saas-operator:0.10.2
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -3425,4 +3440,4 @@ spec:
   provider:
     name: Red Hat
     url: https://www.3scale.net/
-  version: 0.10.1
+  version: 0.10.2

--- a/bundle/manifests/saas.3scale.net_systems.yaml
+++ b/bundle/manifests/saas.3scale.net_systems.yaml
@@ -364,6 +364,26 @@ spec:
                   ampRelease:
                     description: AMP release number
                     type: string
+                  apicastAccessToken:
+                    description: Master access token for Apicast
+                    properties:
+                      fromVault:
+                        description: VaultSecretReference is a reference to a secret stored in a Hashicorp Vault
+                        properties:
+                          key:
+                            description: The Vault key of the secret
+                            type: string
+                          path:
+                            description: The Vault path where the secret is located
+                            type: string
+                        required:
+                        - key
+                        - path
+                        type: object
+                      override:
+                        description: Override allows to directly specify a string value.
+                        type: string
+                    type: object
                   assets:
                     description: Assets has configuration to access assets in AWS s3
                     properties:
@@ -628,7 +648,7 @@ spec:
                     - clientSecret
                     type: object
                   mappingServiceAccessToken:
-                    description: Master access token for Apicast
+                    description: Mapping Service access token
                     properties:
                       fromVault:
                         description: VaultSecretReference is a reference to a secret stored in a Hashicorp Vault
@@ -1143,7 +1163,6 @@ spec:
                 - databaseSecret
                 - eventsSharedSecret
                 - github
-                - mappingServiceAccessToken
                 - memcachedServers
                 - metrics
                 - recaptcha

--- a/config/crd/bases/saas.3scale.net_systems.yaml
+++ b/config/crd/bases/saas.3scale.net_systems.yaml
@@ -511,6 +511,28 @@ spec:
                   ampRelease:
                     description: AMP release number
                     type: string
+                  apicastAccessToken:
+                    description: Master access token for Apicast
+                    properties:
+                      fromVault:
+                        description: VaultSecretReference is a reference to a secret
+                          stored in a Hashicorp Vault
+                        properties:
+                          key:
+                            description: The Vault key of the secret
+                            type: string
+                          path:
+                            description: The Vault path where the secret is located
+                            type: string
+                        required:
+                        - key
+                        - path
+                        type: object
+                      override:
+                        description: Override allows to directly specify a string
+                          value.
+                        type: string
+                    type: object
                   assets:
                     description: Assets has configuration to access assets in AWS
                       s3
@@ -797,7 +819,7 @@ spec:
                     - clientSecret
                     type: object
                   mappingServiceAccessToken:
-                    description: Master access token for Apicast
+                    description: Mapping Service access token
                     properties:
                       fromVault:
                         description: VaultSecretReference is a reference to a secret
@@ -1351,7 +1373,6 @@ spec:
                 - databaseSecret
                 - eventsSharedSecret
                 - github
-                - mappingServiceAccessToken
                 - memcachedServers
                 - metrics
                 - recaptcha

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,4 +13,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/3scale/saas-operator
-  newTag: 0.10.1
+  newTag: 0.10.2

--- a/config/manifests/bases/saas-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/saas-operator.clusterserviceversion.yaml
@@ -1528,6 +1528,21 @@ spec:
       - description: AMP release number
         displayName: AMPRelease
         path: config.ampRelease
+      - description: Master access token for Apicast
+        displayName: Apicast Access Token
+        path: config.apicastAccessToken
+      - description: VaultSecretReference is a reference to a secret stored in a Hashicorp Vault
+        displayName: From Vault
+        path: config.apicastAccessToken.fromVault
+      - description: The Vault key of the secret
+        displayName: Key
+        path: config.apicastAccessToken.fromVault.key
+      - description: The Vault path where the secret is located
+        displayName: Path
+        path: config.apicastAccessToken.fromVault.path
+      - description: Override allows to directly specify a string value.
+        displayName: Override
+        path: config.apicastAccessToken.override
       - description: AWS access key
         displayName: Access Key
         path: config.assets.accessKey
@@ -1708,7 +1723,7 @@ spec:
       - description: Override allows to directly specify a string value.
         displayName: Override
         path: config.github.clientSecret.override
-      - description: Master access token for Apicast
+      - description: Mapping Service access token
         displayName: Mapping Service Access Token
         path: config.mappingServiceAccessToken
       - description: VaultSecretReference is a reference to a secret stored in a Hashicorp Vault

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,7 +1,7 @@
 package version
 
 const (
-	version string = "v0.10.1"
+	version string = "v0.10.2"
 )
 
 // Current returns the current marin3r operator version


### PR DESCRIPTION
This adds both `apicastAccessToken` and `mappingServiceAccessToken` as optional, otherwise OLM gets stuck trying to deploy the new version.

/kind feature
/priority important-soon
/assign