### PR TITLE
fix/backend-hpa

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL:=/bin/bash
 # Current Operator version
-VERSION ?= 0.10.3
+VERSION ?= 0.10.4
 # Default catalog image
 CATALOG_IMG ?= quay.io/3scaleops/saas-operator-bundle:catalog
 # Default bundle image tag

--- a/bundle/manifests/saas-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/saas-operator.clusterserviceversion.yaml
@@ -585,7 +585,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/3scale/saas-operator
     support: Red Hat
-  name: saas-operator.v0.10.3
+  name: saas-operator.v0.10.4
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -3053,7 +3053,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
-                image: quay.io/3scale/saas-operator:0.10.3
+                image: quay.io/3scale/saas-operator:0.10.4
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -3440,4 +3440,4 @@ spec:
   provider:
     name: Red Hat
     url: https://www.3scale.net/
-  version: 0.10.3
+  version: 0.10.4

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,4 +13,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/3scale/saas-operator
-  newTag: 0.10.3
+  newTag: 0.10.4

--- a/controllers/backend_controller.go
+++ b/controllers/backend_controller.go
@@ -96,13 +96,13 @@ func (r *BackendReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 			},
 			{
 				Template: gen.Worker.Deployment(),
-				HasHPA:   !instance.Spec.Listener.HPA.IsDeactivated(),
+				HasHPA:   !instance.Spec.Worker.HPA.IsDeactivated(),
 				//Worker only depends on SystemEventsHookSecretDefinition and ErrorMonitoringSecretDefinition
 				RolloutTriggers: []basereconciler.RolloutTrigger{triggers[0], triggers[2]},
 			},
 			{
 				Template: gen.Cron.Deployment(),
-				HasHPA:   !instance.Spec.Listener.HPA.IsDeactivated(),
+				HasHPA:   false,
 				// Cron only depends on ErrorMonitoringSecretDefinition
 				RolloutTriggers: []basereconciler.RolloutTrigger{triggers[2]},
 			},

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -99,7 +99,7 @@ func dashboardsApicastServicesJsonTpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "dashboards/apicast-services.json.tpl", size: 17460, mode: os.FileMode(420), modTime: time.Unix(1615201850, 0)}
+	info := bindataFileInfo{name: "dashboards/apicast-services.json.tpl", size: 17460, mode: os.FileMode(420), modTime: time.Unix(1614940003, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -119,7 +119,7 @@ func dashboardsApicastJsonTpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "dashboards/apicast.json.tpl", size: 84544, mode: os.FileMode(420), modTime: time.Unix(1615201850, 0)}
+	info := bindataFileInfo{name: "dashboards/apicast.json.tpl", size: 84544, mode: os.FileMode(420), modTime: time.Unix(1614940003, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -139,7 +139,7 @@ func dashboardsAutosslJsonTpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "dashboards/autossl.json.tpl", size: 59358, mode: os.FileMode(420), modTime: time.Unix(1615201850, 0)}
+	info := bindataFileInfo{name: "dashboards/autossl.json.tpl", size: 59358, mode: os.FileMode(420), modTime: time.Unix(1614940003, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -159,7 +159,7 @@ func dashboardsBackendJsonTpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "dashboards/backend.json.tpl", size: 138352, mode: os.FileMode(420), modTime: time.Unix(1615201850, 0)}
+	info := bindataFileInfo{name: "dashboards/backend.json.tpl", size: 138352, mode: os.FileMode(420), modTime: time.Unix(1614940003, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -179,7 +179,7 @@ func dashboardsCorsProxyJsonTpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "dashboards/cors-proxy.json.tpl", size: 78729, mode: os.FileMode(420), modTime: time.Unix(1615201850, 0)}
+	info := bindataFileInfo{name: "dashboards/cors-proxy.json.tpl", size: 78729, mode: os.FileMode(420), modTime: time.Unix(1614940003, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -199,7 +199,7 @@ func dashboardsMappingServiceJsonTpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "dashboards/mapping-service.json.tpl", size: 70520, mode: os.FileMode(420), modTime: time.Unix(1615201850, 0)}
+	info := bindataFileInfo{name: "dashboards/mapping-service.json.tpl", size: 70520, mode: os.FileMode(420), modTime: time.Unix(1614940003, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -219,7 +219,7 @@ func dashboardsSystemJsonTpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "dashboards/system.json.tpl", size: 81336, mode: os.FileMode(420), modTime: time.Unix(1615201850, 0)}
+	info := bindataFileInfo{name: "dashboards/system.json.tpl", size: 81336, mode: os.FileMode(420), modTime: time.Unix(1614940003, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -239,7 +239,7 @@ func dashboardsZyncJsonTpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "dashboards/zync.json.tpl", size: 70296, mode: os.FileMode(420), modTime: time.Unix(1625238899, 0)}
+	info := bindataFileInfo{name: "dashboards/zync.json.tpl", size: 70296, mode: os.FileMode(420), modTime: time.Unix(1625827662, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,7 +1,7 @@
 package version
 
 const (
-	version string = "v0.10.3"
+	version string = "v0.10.4"
 )
 
 // Current returns the current marin3r operator version


### PR DESCRIPTION
Fixes a bug where both cron and worker were setting the "HasHPA" flag using the listener spec. This caused the number of replicas to fall down to 1 on each CR reconcile when the listener had no HPA enabled.

/kind bug
/priority critical-urgent
/assign