### PR TITLE
Fix/system-sidekiq deployments container execution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 SHELL:=/bin/bash
 # Current Operator version
-VERSION ?= 0.10.9
+VERSION ?= 0.10.10
 # Default catalog image
 CATALOG_IMG ?= quay.io/3scaleops/saas-operator-bundle:catalog
 # Default bundle image tag

--- a/bundle/manifests/saas-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/saas-operator.clusterserviceversion.yaml
@@ -165,7 +165,7 @@ metadata:
                     "port": 38081
                   },
                   {
-                    "name": "backend-htttps",
+                    "name": "backend-https",
                     "port": 38443
                   },
                   {
@@ -534,7 +534,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/3scale/saas-operator
     support: Red Hat
-  name: saas-operator.v0.10.9
+  name: saas-operator.v0.10.10
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -3041,7 +3041,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
-                image: quay.io/3scale/saas-operator:0.10.9
+                image: quay.io/3scale/saas-operator:0.10.10
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -3428,4 +3428,4 @@ spec:
   provider:
     name: Red Hat
     url: https://www.3scale.net/
-  version: 0.10.9
+  version: 0.10.10

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,4 +13,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/3scale/saas-operator
-  newTag: 0.10.9
+  newTag: 0.10.10

--- a/controllers/system_controller_suite_test.go
+++ b/controllers/system_controller_suite_test.go
@@ -148,7 +148,7 @@ var _ = Describe("System controller", func() {
 					dep,
 				)
 			}, timeout, poll).ShouldNot(HaveOccurred())
-			Expect(dep.Spec.Template.Spec.Containers[0].Command[5]).To(Equal(
+			Expect(dep.Spec.Template.Spec.Containers[0].Args[1]).To(Equal(
 				"-q critical -q backend_sync -q events -q zync,40 -q priority,25 -q default,15 -q web_hooks,10 -q deletion,5",
 			))
 			Eventually(func() error {
@@ -158,7 +158,7 @@ var _ = Describe("System controller", func() {
 					dep,
 				)
 			}, timeout, poll).ShouldNot(HaveOccurred())
-			Expect(dep.Spec.Template.Spec.Containers[0].Command[5]).To(Equal(
+			Expect(dep.Spec.Template.Spec.Containers[0].Args[1]).To(Equal(
 				"-q billing",
 			))
 			Eventually(func() error {
@@ -168,7 +168,7 @@ var _ = Describe("System controller", func() {
 					dep,
 				)
 			}, timeout, poll).ShouldNot(HaveOccurred())
-			Expect(dep.Spec.Template.Spec.Containers[0].Command[5]).To(Equal(
+			Expect(dep.Spec.Template.Spec.Containers[0].Args[1]).To(Equal(
 				"-q low",
 			))
 

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -99,7 +99,7 @@ func dashboardsApicastServicesJsonTpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "dashboards/apicast-services.json.tpl", size: 17460, mode: os.FileMode(436), modTime: time.Unix(1632845441, 0)}
+	info := bindataFileInfo{name: "dashboards/apicast-services.json.tpl", size: 17460, mode: os.FileMode(436), modTime: time.Unix(1633095083, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -119,7 +119,7 @@ func dashboardsApicastJsonTpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "dashboards/apicast.json.tpl", size: 84544, mode: os.FileMode(436), modTime: time.Unix(1632845441, 0)}
+	info := bindataFileInfo{name: "dashboards/apicast.json.tpl", size: 84544, mode: os.FileMode(436), modTime: time.Unix(1633095083, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -139,7 +139,7 @@ func dashboardsAutosslJsonTpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "dashboards/autossl.json.tpl", size: 59358, mode: os.FileMode(436), modTime: time.Unix(1632845441, 0)}
+	info := bindataFileInfo{name: "dashboards/autossl.json.tpl", size: 59358, mode: os.FileMode(436), modTime: time.Unix(1633095083, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -159,7 +159,7 @@ func dashboardsBackendJsonTpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "dashboards/backend.json.tpl", size: 138352, mode: os.FileMode(436), modTime: time.Unix(1632845441, 0)}
+	info := bindataFileInfo{name: "dashboards/backend.json.tpl", size: 138352, mode: os.FileMode(436), modTime: time.Unix(1633095083, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -179,7 +179,7 @@ func dashboardsCorsProxyJsonTpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "dashboards/cors-proxy.json.tpl", size: 78729, mode: os.FileMode(436), modTime: time.Unix(1632845441, 0)}
+	info := bindataFileInfo{name: "dashboards/cors-proxy.json.tpl", size: 78729, mode: os.FileMode(436), modTime: time.Unix(1633095083, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -199,7 +199,7 @@ func dashboardsMappingServiceJsonTpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "dashboards/mapping-service.json.tpl", size: 70520, mode: os.FileMode(436), modTime: time.Unix(1632845441, 0)}
+	info := bindataFileInfo{name: "dashboards/mapping-service.json.tpl", size: 70520, mode: os.FileMode(436), modTime: time.Unix(1633095083, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -219,7 +219,7 @@ func dashboardsSystemJsonTpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "dashboards/system.json.tpl", size: 81330, mode: os.FileMode(436), modTime: time.Unix(1632845448, 0)}
+	info := bindataFileInfo{name: "dashboards/system.json.tpl", size: 81330, mode: os.FileMode(436), modTime: time.Unix(1633095083, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -239,7 +239,7 @@ func dashboardsZyncJsonTpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "dashboards/zync.json.tpl", size: 70296, mode: os.FileMode(436), modTime: time.Unix(1632845441, 0)}
+	info := bindataFileInfo{name: "dashboards/zync.json.tpl", size: 70296, mode: os.FileMode(436), modTime: time.Unix(1633095083, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/pkg/generators/system/sidekiq_deployment.go
+++ b/pkg/generators/system/sidekiq_deployment.go
@@ -54,11 +54,7 @@ func (gen *SidekiqGenerator) Deployment() basereconciler.GeneratorFunction {
 							{
 								Name:  gen.GetComponent(),
 								Image: fmt.Sprintf("%s:%s", *gen.ImageSpec.Name, *gen.ImageSpec.Tag),
-								Args: func() (args []string) {
-									args = []string{"sidekiq"}
-									args = append(args, *gen.Spec.Config.QueuesArg)
-									return
-								}(),
+								Args:  []string{"sidekiq", *gen.Spec.Config.QueuesArg},
 								Env: func() []corev1.EnvVar {
 									envVars := pod.BuildEnvironment(gen.Options)
 									envVars = append(envVars,

--- a/pkg/generators/system/sidekiq_deployment.go
+++ b/pkg/generators/system/sidekiq_deployment.go
@@ -54,9 +54,9 @@ func (gen *SidekiqGenerator) Deployment() basereconciler.GeneratorFunction {
 							{
 								Name:  gen.GetComponent(),
 								Image: fmt.Sprintf("%s:%s", *gen.ImageSpec.Name, *gen.ImageSpec.Tag),
-								Command: func() (command []string) {
-									command = []string{"/usr/bin/bash", "-c", "bundle", "exec", "sidekiq"}
-									command = append(command, *gen.Spec.Config.QueuesArg)
+								Args: func() (args []string) {
+									args = []string{"sidekiq"}
+									args = append(args, *gen.Spec.Config.QueuesArg)
 									return
 								}(),
 								Env: func() []corev1.EnvVar {

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,7 +1,7 @@
 package version
 
 const (
-	version string = "v0.10.9"
+	version string = "v0.10.10"
 )
 
 // Current returns the current marin3r operator version


### PR DESCRIPTION
On #125 it was introduced the split of an unique system-sidekiq deployment into 3 different deployments.

On that PR it was changed the default container `args` with some harcoded ENVVAR... :
```
           args:
             - rake
             - 'sidekiq:worker'
             - RAILS_MAX_THREADS=25
```

By `command`, where the queuesArgument (`-q billing` for example) comes from a CRD field which ahs already a default value:
```
           command:
             - /usr/bin/bash
             - '-c'
             - bundle
             - exec
             - sidekiq
             - '-q billing'
```

However it was introduced a bug in which containers cannot start, showing in logs:
```
There was an error while trying to write to `/opt/system/.bundle/config`. It is
likely that you need to grant write permissions for that path.
```

The reason is that source container entrypoint uses `sh` not `bash`:
```
#!/bin/sh
bundle exec bin/rails db:setup 2> /dev/null || bundle exec bin/rails db:migrate
exec bundle exec "$@"
```

So to simplify it, and not have to specify `sh` or `bash`..., it will use just the entrypoint (so replacing `command` by `args`), and only 2 arguments are required:
```
           args:
             - sidekiq
             - '-q billing'
```


/kind bug
/priority important-soon
/assign

**Note: To be merged once `saas-operator:v0.10.9` gets deployed into production (to be done next Monday 4th Oct 2021).**