### PR TITLE
Update system-sidekiq-low deployment to manage new mailers queue

### DIFF
--- a/api/v1alpha1/system_types.go
+++ b/api/v1alpha1/system_types.go
@@ -151,7 +151,9 @@ var (
 		MaxThreads: pointer.Int32Ptr(15),
 	}
 	systemDefaultSidekiqConfigLow defaultSidekiqConfig = defaultSidekiqConfig{
-		Queues:     []string{"low"},
+		Queues: []string{
+			"mailers", "low",
+		},
 		MaxThreads: pointer.Int32Ptr(15),
 	}
 

--- a/controllers/system_controller_suite_test.go
+++ b/controllers/system_controller_suite_test.go
@@ -171,7 +171,7 @@ var _ = Describe("System controller", func() {
 				)
 			}, timeout, poll).ShouldNot(HaveOccurred())
 			Expect(dep.Spec.Template.Spec.Containers[0].Args).To(Equal(
-				[]string{"sidekiq", "--queue", "low"},
+				[]string{"sidekiq", "--queue", "mailers", "--queue", "low"},
 			))
 			Expect(dep.Spec.Template.Spec.Volumes[0].Name).To(Equal("system-tmp"))
 			Expect(dep.Spec.Template.Spec.Volumes[1].Secret.SecretName).To(Equal("system-config"))


### PR DESCRIPTION
Related to https://github.com/3scale/deploy/pull/721/files

Adds a new `mailers` queue on the sidekiq low deployment, to send mails on async mode.

/kind feature
/priority important-soon
/assign