### PR TITLE
Adjust operator resources

### DIFF
--- a/config/default/custom/manager_patch.yaml
+++ b/config/default/custom/manager_patch.yaml
@@ -18,11 +18,11 @@ spec:
             - --leader-elect
           resources:
             limits:
-              cpu: 50m
-              memory: 700Mi
+              cpu: 500m
+              memory: 1Gi
             requests:
               cpu: 25m
-              memory: 200Mi
+              memory: 550Mi
           ports:
             - containerPort: 8080
               protocol: TCP


### PR DESCRIPTION
* Raise memory limit as the operator has a memmory consumption spike
  when it starts that can cause crashloopback if the limit is too low
* Raise CPU limit to half a CPU to speed up operator reconcile loops.
  Average memory consumption is very low, but we need to allow
consumption spikes to speed up reconcile operations.

/kind bug
/priority important-soon
/assign