### PR TITLE
feat/twemproxy-restart-on-failover

### DIFF
--- a/api/v1alpha1/twemproxyconfig_types.go
+++ b/api/v1alpha1/twemproxyconfig_types.go
@@ -21,6 +21,12 @@ import (
 
 	"github.com/3scale/saas-operator/pkg/util"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+var (
+	PodSyncLabelKey   string = fmt.Sprintf("%s/twemproxyconfig.sync", GroupVersion.Group)
+	SyncAnnotationKey string = fmt.Sprintf("%s/twemproxyconfig.configmap-hash", GroupVersion.Group)
 )
 
 // TwemproxyConfigSpec defines the desired state of TwemproxyConfig
@@ -84,15 +90,9 @@ type TwemproxyConfig struct {
 	Status TwemproxyConfigStatus `json:"status,omitempty"`
 }
 
-func (tc *TwemproxyConfig) SyncLabel() map[string]string {
-	return map[string]string{
-		fmt.Sprintf("%s/twemproxyconfig/sync", GroupVersion.Group): util.ObjectKey(tc).String(),
-	}
-}
-
-func (tc *TwemproxyConfig) SyncAnnotation(hash string) map[string]string {
-	return map[string]string{
-		fmt.Sprintf("%s/twemproxyconfig.configmap-hash", GroupVersion.Group): hash,
+func (tc *TwemproxyConfig) PodSyncSelector() client.MatchingLabels {
+	return client.MatchingLabels{
+		PodSyncLabelKey: util.ObjectKey(tc).Name,
 	}
 }
 

--- a/api/v1alpha1/twemproxyconfig_types.go
+++ b/api/v1alpha1/twemproxyconfig_types.go
@@ -17,6 +17,9 @@ limitations under the License.
 package v1alpha1
 
 import (
+	"fmt"
+
+	"github.com/3scale/saas-operator/pkg/util"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -79,6 +82,18 @@ type TwemproxyConfig struct {
 
 	Spec   TwemproxyConfigSpec   `json:"spec,omitempty"`
 	Status TwemproxyConfigStatus `json:"status,omitempty"`
+}
+
+func (tc *TwemproxyConfig) SyncLabel() map[string]string {
+	return map[string]string{
+		fmt.Sprintf("%s/twemproxyconfig/sync", GroupVersion.Group): util.ObjectKey(tc).String(),
+	}
+}
+
+func (tc *TwemproxyConfig) SyncAnnotation(hash string) map[string]string {
+	return map[string]string{
+		fmt.Sprintf("%s/twemproxyconfig.configmap-hash", GroupVersion.Group): hash,
+	}
 }
 
 //+kubebuilder:object:root=true

--- a/config/rbac/role.yaml
+++ b/config/rbac/role.yaml
@@ -46,10 +46,23 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - configmaps
+  verbs:
+  - create
+  - delete
+  - get
+  - list
+  - patch
+  - update
+  - watch
+- apiGroups:
+  - ""
+  resources:
   - pods
   verbs:
   - get
   - list
+  - patch
   - watch
 - apiGroups:
   - ""

--- a/controllers/twemproxyconfig_controller.go
+++ b/controllers/twemproxyconfig_controller.go
@@ -18,6 +18,9 @@ package controllers
 
 import (
 	"context"
+	"fmt"
+	"reflect"
+	"sync"
 	"time"
 
 	saasv1alpha1 "github.com/3scale/saas-operator/api/v1alpha1"
@@ -28,11 +31,11 @@ import (
 	"github.com/3scale/saas-operator/pkg/util"
 	"github.com/go-logr/logr"
 	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
@@ -47,7 +50,8 @@ type TwemproxyConfigReconciler struct {
 // +kubebuilder:rbac:groups=saas.3scale.net,namespace=placeholder,resources=twemproxyconfigs,verbs=get;list;watch;create;update;patch;delete
 // +kubebuilder:rbac:groups=saas.3scale.net,namespace=placeholder,resources=twemproxyconfigs/status,verbs=get;update;patch
 // +kubebuilder:rbac:groups=saas.3scale.net,namespace=placeholder,resources=twemproxyconfigs/finalizers,verbs=update
-// +kubebuilder:rbac:groups="core",namespace=placeholder,resources=services,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="core",namespace=placeholder,resources=configmaps,verbs=get;list;watch;create;update;patch;delete
+// +kubebuilder:rbac:groups="core",namespace=placeholder,resources=pods,verbs=list;patch
 
 // Reconcile is part of the main kubernetes reconciliation loop which aims to
 // move the current state of the cluster closer to the desired state.
@@ -73,7 +77,16 @@ func (r *TwemproxyConfigReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	}
 
 	// Reconcile the ConfigMap
-	if err := r.reconcileConfigMap(ctx, cm.(*corev1.ConfigMap), log); err != nil {
+	if err := r.reconcileConfigMap(ctx, instance, cm.(*corev1.ConfigMap), log); err != nil {
+		return r.ManageError(ctx, instance, err)
+	}
+
+	// Reconcile sync annotations in pods. This is done to force a change in the target
+	// Pods annotations so the ConfigMap is re-synced inside the container. Otherwide kubelet
+	// would re-sync the file asynchronously depending on its configured refresh time, which might
+	// take several seconds.
+	hash := util.Hash(cm.(*corev1.ConfigMap).Data)
+	if err := r.reconcileSyncAnnotations(ctx, instance, hash, log); err != nil {
 		return r.ManageError(ctx, instance, err)
 	}
 
@@ -92,13 +105,15 @@ func (r *TwemproxyConfigReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 	return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
 }
 
-func (r *TwemproxyConfigReconciler) reconcileConfigMap(ctx context.Context, desired *corev1.ConfigMap, log logr.Logger) error {
-
+func (r *TwemproxyConfigReconciler) reconcileConfigMap(ctx context.Context, owner client.Object, desired *corev1.ConfigMap, log logr.Logger) error {
 	current := &corev1.ConfigMap{}
 	err := r.GetClient().Get(ctx, util.ObjectKey(desired), current)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			// Create
+			if err := controllerutil.SetControllerReference(owner, desired, r.GetScheme()); err != nil {
+				return err
+			}
 			if err := r.GetClient().Create(ctx, desired); err != nil {
 				return err
 			}
@@ -111,7 +126,7 @@ func (r *TwemproxyConfigReconciler) reconcileConfigMap(ctx context.Context, desi
 	// Compare .data field of both ConfigMaps and patch if required
 	// We use patch to avoid failures due to having an older version
 	// of the configmap so the config changes are propagated faster.
-	if !equality.Semantic.DeepEqual(desired.Data, current.Data) {
+	if !reflect.DeepEqual(desired.Data, current.Data) {
 		if err := r.GetClient().Patch(ctx, desired, client.MergeFrom(current)); err != nil {
 			log.Error(err, "unable to patch ConfigMap")
 			return err
@@ -122,11 +137,74 @@ func (r *TwemproxyConfigReconciler) reconcileConfigMap(ctx context.Context, desi
 	return nil
 }
 
+func (r *TwemproxyConfigReconciler) reconcileSyncAnnotations(ctx context.Context,
+	instance *saasv1alpha1.TwemproxyConfig, hash string, log logr.Logger) error {
+
+	podList := &corev1.PodList{}
+	if err := r.GetClient().List(ctx, podList, instance.PodSyncSelector(),
+		client.InNamespace(instance.GetNamespace())); err != nil {
+		return err
+	}
+
+	failures := util.MultiError{}
+	errCh := make(chan error)
+	innerCtx, cancel := context.WithTimeout(ctx, 5*time.Second)
+	var wg sync.WaitGroup
+
+	// listen the error channel for errors
+	go func() {
+		for {
+			select {
+			case err := <-errCh:
+				failures = append(failures, err)
+			case <-innerCtx.Done():
+				return
+			}
+		}
+	}()
+
+	// Patch the Pods concurrently
+	for _, pod := range podList.Items {
+		wg.Add(1)
+		go func(pod corev1.Pod) {
+			r.syncPod(innerCtx, pod, hash, errCh, log)
+			wg.Done()
+		}(pod)
+	}
+
+	wg.Wait()
+	cancel()
+	if len(failures) > 0 {
+		return failures
+	}
+
+	return nil
+}
+
+func (r *TwemproxyConfigReconciler) syncPod(ctx context.Context, pod corev1.Pod, hash string, errCh chan<- error, log logr.Logger) {
+	annotatedHash, ok := pod.GetAnnotations()[saasv1alpha1.SyncAnnotationKey]
+	if !ok || annotatedHash != hash {
+		patch := client.MergeFrom(pod.DeepCopy())
+		if pod.GetAnnotations() != nil {
+			pod.ObjectMeta.Annotations[saasv1alpha1.SyncAnnotationKey] = hash
+		} else {
+			pod.ObjectMeta.Annotations = map[string]string{
+				saasv1alpha1.SyncAnnotationKey: hash,
+			}
+		}
+
+		if err := r.GetClient().Patch(ctx, &pod, patch); err != nil {
+			errCh <- err
+		}
+		log.V(1).Info(fmt.Sprintf("configmap re-sync forced in target pod %s", util.ObjectKey(&pod)))
+	}
+}
+
 // SetupWithManager sets up the controller with the Manager.
 func (r *TwemproxyConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&saasv1alpha1.TwemproxyConfig{}).
-		Watches(&source.Channel{Source: r.GetStatusChangeChannel()}, &handler.EnqueueRequestForObject{}).
+		Owns(&corev1.ConfigMap{}).
 		Watches(&source.Channel{Source: r.SentinelEvents.GetChannel()}, &handler.EnqueueRequestForObject{}).
 		Complete(r)
 }

--- a/pkg/generators/twemproxyconfig/generator.go
+++ b/pkg/generators/twemproxyconfig/generator.go
@@ -76,12 +76,10 @@ func (gen *Generator) getMonitoredShards(ctx context.Context) (map[string]Twempr
 	return m, nil
 }
 
-// Returns all the resource templates that this generator manages
-func (gen *Generator) Resources() []basereconciler.Resource {
-	return []basereconciler.Resource{
-		basereconciler_resources.ConfigMapTemplate{
-			Template:  gen.configMap(true),
-			IsEnabled: true,
-		},
+// Returns the twemproxy config ConfigMap
+func (gen *Generator) ConfigMap() basereconciler.Resource {
+	return basereconciler_resources.ConfigMapTemplate{
+		Template:  gen.configMap(true),
+		IsEnabled: true,
 	}
 }

--- a/pkg/util/error.go
+++ b/pkg/util/error.go
@@ -1,9 +1,32 @@
 package util
 
-import "fmt"
+import (
+	"encoding/json"
+	"fmt"
+)
 
 // WrapError can be used to provide information about the
 // context where the error occured
 func WrapError(context string, err error) error {
 	return fmt.Errorf("[%s] %s", context, err.Error())
+}
+
+// Type MultiError can be used for iterative operations that
+// must keep going even if errors are detected. It will return
+// the list of all encountered errors. MultiError implements the
+// Error interface and can be passed around as a normal error.
+type MultiError []error
+
+// Ensure the Error interface is implemented
+var _ error = MultiError{}
+
+func (me MultiError) Error() string {
+
+	list := make([]string, 0, len(me))
+	for _, err := range me {
+		list = append(list, err.Error())
+	}
+
+	b, _ := json.Marshal(list)
+	return string(b)
 }

--- a/pkg/util/error_test.go
+++ b/pkg/util/error_test.go
@@ -1,0 +1,31 @@
+package util
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestMultiError_Error(t *testing.T) {
+	tests := []struct {
+		name string
+		me   MultiError
+		want string
+	}{
+		{
+			name: "Returns several errors",
+			me: []error{
+				errors.New("error1"),
+				errors.New("error2"),
+				errors.New("error3"),
+			},
+			want: `["error1","error2","error3"]`,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.me.Error(); got != tt.want {
+				t.Errorf("MultiError.Error() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
* Drop usage of the operator-utils LockedResourceReconciler to reconcile the Twemproxy ConfigMap to improve the refresh times (it was taking ~1s per config update)
* Make the TwemproxyConfig controller patch the Pods that have the ConfigMap mounted with an annotation when the ConfigMap is updated. This forces a kubelet re-sync of the Pod, which updates the mounted files from secrets/configmaps. Otherwise, it might take several seconds for the ConfigMap contents to be updated inside the container, depending on the refresh time that kubelet has configured.
* Initial tests show that it now takes ~200ms since the failover event is received from sentinel until twemproxy is restarted with the new config.

/kind feature
/priority important-soon
/assign