### PR TITLE
feat: fix autossl svc selector

### DIFF
--- a/pkg/generators/autossl/generator.go
+++ b/pkg/generators/autossl/generator.go
@@ -42,6 +42,7 @@ func NewGenerator(instance, namespace string, spec saasv1alpha1.AutoSSLSpec) (Ge
 		},
 		Spec:    spec,
 		Options: config.NewOptions(spec),
+		Traffic: true,
 	}
 
 	if spec.Canary != nil {


### PR DESCRIPTION
Fixes the empty service selector bug and adds some tests to `autossl` to verify the service selects.

/kind bug
/priority important-soon
/assign