### PR TITLE
feat: upgrade cors-proxy to v2 workload reconciler

### DIFF
--- a/controllers/corsproxy_controller.go
+++ b/controllers/corsproxy_controller.go
@@ -65,14 +65,11 @@ func (r *CORSProxyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	// Apply defaults for reconcile but do not store them in the API
 	instance.Default()
 
-	gen, err := corsproxy.NewGenerator(
+	gen := corsproxy.NewGenerator(
 		instance.GetName(),
 		instance.GetNamespace(),
 		instance.Spec,
 	)
-	if err != nil {
-		return r.ManageError(ctx, instance, err)
-	}
 
 	resources := []basereconciler.Resource{
 		gen.GrafanaDashboard(),

--- a/controllers/corsproxy_controller_suite_test.go
+++ b/controllers/corsproxy_controller_suite_test.go
@@ -74,10 +74,7 @@ var _ = Describe("CORSProxy controller", func() {
 			Eventually(func() bool {
 				err := k8sClient.Get(context.Background(), types.NamespacedName{Name: "instance", Namespace: namespace}, corsproxy)
 				Expect(err).ToNot(HaveOccurred())
-				if len(corsproxy.GetFinalizers()) > 0 {
-					return true
-				}
-				return false
+				return len(corsproxy.GetFinalizers()) > 0
 			}, timeout, poll).Should(BeTrue())
 
 			dep := &appsv1.Deployment{}

--- a/controllers/echoapi_controller.go
+++ b/controllers/echoapi_controller.go
@@ -61,14 +61,11 @@ func (r *EchoAPIReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	// Apply defaults for reconcile but do not store them in the API
 	instance.Default()
 
-	gen, err := echoapi.NewGenerator(
+	gen := echoapi.NewGenerator(
 		instance.GetName(),
 		instance.GetNamespace(),
 		instance.Spec,
 	)
-	if err != nil {
-		return r.ManageError(ctx, instance, err)
-	}
 
 	resources, err := r.NewDeploymentWorkloadWithTraffic(ctx, instance, r.GetScheme(), &gen, &gen)
 	if err != nil {

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -135,8 +135,8 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 
 	err = (&CORSProxyReconciler{
-		Reconciler: basereconciler.NewFromManager(mgr, mgr.GetEventRecorderFor("CORSProxy"), false),
-		Log:        ctrl.Log.WithName("controllers").WithName("CORSProxy"),
+		WorkloadReconciler: workloads.NewFromManager(mgr, mgr.GetEventRecorderFor("CORSProxy"), false),
+		Log:                ctrl.Log.WithName("controllers").WithName("CORSProxy"),
 	}).SetupWithManager(mgr)
 	Expect(err).ToNot(HaveOccurred())
 

--- a/main.go
+++ b/main.go
@@ -139,14 +139,6 @@ func main() {
 		os.Exit(1)
 	}
 
-	if err = (&controllers.CORSProxyReconciler{
-		Reconciler: basereconciler.NewFromManager(mgr, mgr.GetEventRecorderFor("CORSProxy"), false),
-		Log:        ctrl.Log.WithName("controllers").WithName("CORSProxy"),
-	}).SetupWithManager(mgr); err != nil {
-		setupLog.Error(err, "unable to create controller", "controller", "CORSProxy")
-		os.Exit(1)
-	}
-
 	if err = (&controllers.SystemReconciler{
 		Reconciler: basereconciler.NewFromManager(mgr, mgr.GetEventRecorderFor("System"), false),
 		Log:        ctrl.Log.WithName("controllers").WithName("System"),
@@ -191,6 +183,14 @@ func main() {
 	}
 
 	/* WORKLOADS RECONCILER BASED CONTROLLERS*/
+
+	if err = (&controllers.CORSProxyReconciler{
+		WorkloadReconciler: workloads.NewFromManager(mgr, mgr.GetEventRecorderFor("CORSProxy"), false),
+		Log:                ctrl.Log.WithName("controllers").WithName("CORSProxy"),
+	}).SetupWithManager(mgr); err != nil {
+		setupLog.Error(err, "unable to create controller", "controller", "CORSProxy")
+		os.Exit(1)
+	}
 
 	if err = (&controllers.AutoSSLReconciler{
 		WorkloadReconciler: workloads.NewFromManager(mgr, mgr.GetEventRecorderFor("AutoSSL"), false),

--- a/pkg/generators/corsproxy/config/options.go
+++ b/pkg/generators/corsproxy/config/options.go
@@ -2,7 +2,7 @@ package config
 
 import (
 	saasv1alpha1 "github.com/3scale/saas-operator/api/v1alpha1"
-	"github.com/3scale/saas-operator/pkg/generators/common_blocks/pod"
+	"github.com/3scale/saas-operator/pkg/resource_builders/pod"
 )
 
 // Options holds configuration for the cors-proxy pod

--- a/pkg/generators/corsproxy/deployment.go
+++ b/pkg/generators/corsproxy/deployment.go
@@ -3,35 +3,21 @@ package corsproxy
 import (
 	"fmt"
 
-	"github.com/3scale/saas-operator/pkg/generators/common_blocks/pod"
-	basereconciler "github.com/3scale/saas-operator/pkg/reconcilers/basereconciler/v1"
+	"github.com/3scale/saas-operator/pkg/resource_builders/pod"
 	"github.com/3scale/saas-operator/pkg/util"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// Deployment returns a basereconciler.GeneratorFunction function that will return a Deployment
-// resource when called
-func (gen *Generator) Deployment() basereconciler.GeneratorFunction {
+// deployment returns a function that will return a *appsv1.Deployment for echo-api
+func (gen *Generator) deployment() func() *appsv1.Deployment {
 
-	return func() client.Object {
+	return func() *appsv1.Deployment {
 
 		return &appsv1.Deployment{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       "Deployment",
-				APIVersion: appsv1.SchemeGroupVersion.String(),
-			},
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      gen.GetComponent(),
-				Namespace: gen.Namespace,
-				Labels:    gen.GetLabels(),
-			},
 			Spec: appsv1.DeploymentSpec{
 				Replicas: gen.Spec.Replicas,
-				Selector: gen.Selector(),
 				Strategy: appsv1.DeploymentStrategy{
 					Type: appsv1.RollingUpdateDeploymentStrategyType,
 					RollingUpdate: &appsv1.RollingUpdateDeployment{
@@ -40,9 +26,6 @@ func (gen *Generator) Deployment() basereconciler.GeneratorFunction {
 					},
 				},
 				Template: corev1.PodTemplateSpec{
-					ObjectMeta: metav1.ObjectMeta{
-						Labels: gen.LabelsWithSelector(),
-					},
 					Spec: corev1.PodSpec{
 						ImagePullSecrets: func() []corev1.LocalObjectReference {
 							if gen.Spec.Image.PullSecretName != nil {
@@ -67,7 +50,7 @@ func (gen *Generator) Deployment() basereconciler.GeneratorFunction {
 								TerminationMessagePolicy: corev1.TerminationMessageReadFile,
 							},
 						},
-						Affinity:    pod.Affinity(gen.Selector().MatchLabels, gen.Spec.NodeAffinity),
+						Affinity:    pod.Affinity(gen.GetSelector(), gen.Spec.NodeAffinity),
 						Tolerations: gen.Spec.Tolerations,
 					},
 				},

--- a/pkg/generators/corsproxy/generator.go
+++ b/pkg/generators/corsproxy/generator.go
@@ -28,22 +28,21 @@ type Generator struct {
 }
 
 // NewGenerator returns a new Options struct
-func NewGenerator(instance, namespace string, spec saasv1alpha1.CORSProxySpec) (Generator, error) {
+func NewGenerator(instance, namespace string, spec saasv1alpha1.CORSProxySpec) Generator {
 	return Generator{
-			BaseOptionsV2: generators.BaseOptionsV2{
-				Component:    component,
-				InstanceName: instance,
-				Namespace:    namespace,
-				Labels: map[string]string{
-					"app":     component,
-					"part-of": "3scale-saas",
-				},
+		BaseOptionsV2: generators.BaseOptionsV2{
+			Component:    component,
+			InstanceName: instance,
+			Namespace:    namespace,
+			Labels: map[string]string{
+				"app":     component,
+				"part-of": "3scale-saas",
 			},
-			Spec:    spec,
-			Options: config.NewOptions(spec),
-			Traffic: true,
 		},
-		nil
+		Spec:    spec,
+		Options: config.NewOptions(spec),
+		Traffic: true,
+	}
 }
 
 // Validate that Generator implements workloads.TrafficManager interface

--- a/pkg/generators/corsproxy/service.go
+++ b/pkg/generators/corsproxy/service.go
@@ -1,29 +1,20 @@
 package corsproxy
 
 import (
-	"github.com/3scale/saas-operator/pkg/generators/common_blocks/service"
-	basereconciler "github.com/3scale/saas-operator/pkg/reconcilers/basereconciler/v1"
+	"github.com/3scale/saas-operator/pkg/resource_builders/service"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
-// Service returns a basereconciler.GeneratorFunction function that will return the
-// Service resource when called
-func (gen *Generator) Service() basereconciler.GeneratorFunction {
+// service returns a function that will return the corev1.Service for echo-api
+func (gen *Generator) service() func() *corev1.Service {
 
-	return func() client.Object {
+	return func() *corev1.Service {
 
 		return &corev1.Service{
-			TypeMeta: metav1.TypeMeta{
-				Kind:       "Service",
-				APIVersion: corev1.SchemeGroupVersion.String(),
-			},
 			ObjectMeta: metav1.ObjectMeta{
-				Name:      gen.GetComponent(),
-				Namespace: gen.GetNamespace(),
-				Labels:    gen.GetLabels(),
+				Name: gen.GetComponent(),
 			},
 			Spec: corev1.ServiceSpec{
 				Type:            corev1.ServiceTypeClusterIP,
@@ -31,7 +22,6 @@ func (gen *Generator) Service() basereconciler.GeneratorFunction {
 				Ports: service.Ports(
 					service.TCPPort("http", 80, intstr.FromString("http")),
 				),
-				Selector: gen.Selector().MatchLabels,
 			},
 		}
 	}

--- a/pkg/generators/echoapi/generator.go
+++ b/pkg/generators/echoapi/generator.go
@@ -23,21 +23,20 @@ type Generator struct {
 }
 
 // NewGenerator returns a new Options struct
-func NewGenerator(instance, namespace string, spec saasv1alpha1.EchoAPISpec) (Generator, error) {
+func NewGenerator(instance, namespace string, spec saasv1alpha1.EchoAPISpec) Generator {
 	return Generator{
-			BaseOptionsV2: generators.BaseOptionsV2{
-				Component:    component,
-				InstanceName: instance,
-				Namespace:    namespace,
-				Labels: map[string]string{
-					"app":     component,
-					"part-of": "3scale-saas",
-				},
+		BaseOptionsV2: generators.BaseOptionsV2{
+			Component:    component,
+			InstanceName: instance,
+			Namespace:    namespace,
+			Labels: map[string]string{
+				"app":     component,
+				"part-of": "3scale-saas",
 			},
-			Spec:    spec,
-			Traffic: true,
 		},
-		nil
+		Spec:    spec,
+		Traffic: true,
+	}
 }
 
 // Validate that Generator implements workloads.TrafficManager interface


### PR DESCRIPTION
Solves part of  https://github.com/3scale-ops/saas-operator/issues/152

- Implements the corsproxy controller using the new workload reconciler added in #144.
- In addition, it updates also the echo-api controller generator by removing error var, because generator function never returns an error https://github.com/3scale-ops/saas-operator/pull/157/commits/34ecee62ac2a899cae48b0caf54009b9a6fd6e08


/kind feature
/priority important-soon