### PR TITLE
doc/examples/local-backend-env

### DIFF
--- a/examples/backend/README.md
+++ b/examples/backend/README.md
@@ -1,0 +1,42 @@
+# NOTES
+
+* Create a cluster
+
+```bash
+kubectl kind-create
+kubectl kind-deploy
+export KUBECONFIG=$PWD/kubeconfig
+```
+
+* Deploy first the RedisShards for redis-storage and redis-resque
+
+```bash
+kubectl apply -f examples/backend/redis.yaml
+```
+
+* Wait until the redis Pods are ready, otherwise the sentinel controller will start giving a lot of errors and will end up taking a very long time to properly reconcile due to controller reconcile throttling. Once the redis Pods are ready, apply the rest of the manifests.
+
+```bash
+kubectl apply -f examples/backend/
+```
+
+* In the end you should have something like this:
+
+```bash
+❯ kubectl get pods
+NAME                                                READY   STATUS    RESTARTS   AGE
+backend-cron-c89c5f5d5-s4xqx                        1/1     Running   0          101s
+backend-listener-7684f5dbd8-vgf96                   2/2     Running   0          102s
+backend-worker-6fb65b7c6b-2gwn5                     2/2     Running   0          101s
+redis-sentinel-0                                    1/1     Running   0          108s
+redis-sentinel-1                                    1/1     Running   0          108s
+redis-sentinel-2                                    1/1     Running   0          107s
+redis-shard-resque-0                                1/1     Running   0          3m32s
+redis-shard-shard01-0                               1/1     Running   0          3m37s
+redis-shard-shard01-1                               1/1     Running   0          3m37s
+redis-shard-shard01-2                               1/1     Running   0          3m37s
+redis-shard-shard02-0                               1/1     Running   0          3m36s
+redis-shard-shard02-1                               1/1     Running   0          3m36s
+redis-shard-shard02-2                               1/1     Running   0          3m36s
+saas-operator-controller-manager-57474ff9c4-fwlss   1/1     Running   1          46m
+```

--- a/examples/backend/backend.yaml
+++ b/examples/backend/backend.yaml
@@ -1,0 +1,46 @@
+---
+apiVersion: saas.3scale.net/v1alpha1
+kind: Backend
+metadata:
+  name: backned
+spec:
+  image:
+    tag: v3.4.3
+  config:
+    rackEnv: preview
+    redisStorageDSN: redis://127.0.0.1:22121
+    redisQueuesDSN: redis://redis-shard-resque-0.redis-shard-resque:6379
+    systemEventsHookURL:
+      override: https://master:3000/master/events/import
+    systemEventsHookPassword:
+      override: megalol
+    internalAPIUser:
+      override: multitenant
+    internalAPIPassword:
+      override: superlol
+  listener:
+    replicas: 1
+    hpa: {}
+    pdb: {}
+    endpoint:
+      dns:
+        - backend.example.net
+    resources: {}
+  worker:
+    config:
+      redisAsync: true
+    replicas: 1
+    hpa: {}
+    pdb: {}
+    resources: {}
+  cron:
+    replicas: 1
+    resources: {}
+  twemproxy:
+    twemproxyConfigRef: backend-twemproxyconfig
+    image:
+      name: quay.io/3scale/twemproxy
+      tag: v0.5.0
+    options:
+      logLevel: 6
+      statsInterval: 10s

--- a/examples/backend/redis.yaml
+++ b/examples/backend/redis.yaml
@@ -1,0 +1,21 @@
+apiVersion: saas.3scale.net/v1alpha1
+kind: RedisShard
+metadata:
+  name: shard01
+spec: {}
+
+---
+apiVersion: saas.3scale.net/v1alpha1
+kind: RedisShard
+metadata:
+  name: shard02
+spec: {}
+
+---
+---
+apiVersion: saas.3scale.net/v1alpha1
+kind: RedisShard
+metadata:
+  name: resque
+spec:
+  slaveCount: 0

--- a/examples/backend/sentinel.yaml
+++ b/examples/backend/sentinel.yaml
@@ -1,0 +1,19 @@
+apiVersion: saas.3scale.net/v1alpha1
+kind: Sentinel
+metadata:
+  name: sentinel
+spec:
+  replicas: 3
+  config:
+    monitoredShards:
+      # DNS should not be used in production. DNS is
+      # used here for convenience as redis IPs might change
+      # inside the cluster.
+      shard01:
+        - redis://redis-shard-shard01-0.redis-shard-shard01:6379
+        - redis://redis-shard-shard01-1.redis-shard-shard01:6379
+        - redis://redis-shard-shard01-2.redis-shard-shard01:6379
+      shard02:
+        - redis://redis-shard-shard02-0.redis-shard-shard02:6379
+        - redis://redis-shard-shard02-1.redis-shard-shard02:6379
+        - redis://redis-shard-shard02-2.redis-shard-shard02:6379

--- a/examples/backend/twemproxyconfig-masters.yaml
+++ b/examples/backend/twemproxyconfig-masters.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: saas.3scale.net/v1alpha1
+kind: TwemproxyConfig
+metadata:
+  name: backend-twemproxyconfig
+spec:
+  reconcileServerPools: false
+  serverPools:
+    - name: test
+      bindAddress: 0.0.0.0:22121
+      timeout: 5000
+      tcpBacklog: 512
+      preConnect: false
+      topology:
+        - shardName: logical-shard01
+          physicalShard: shard01
+        - shardName: logical-shard02
+          physicalShard: shard01
+        - shardName: logical-shard03
+          physicalShard: shard01
+        - shardName: logical-shard04
+          physicalShard: shard02
+        - shardName: logical-shard05
+          physicalShard: shard02

--- a/examples/backend/twemproxyconfig-slaves-rw.yaml
+++ b/examples/backend/twemproxyconfig-slaves-rw.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: saas.3scale.net/v1alpha1
+kind: TwemproxyConfig
+metadata:
+  name: system-twemproxyconfig
+spec:
+  serverPools:
+    - name: test
+      bindAddress: 0.0.0.0:22121
+      target: slaves-rw
+      timeout: 5000
+      tcpBacklog: 512
+      preConnect: false
+      topology:
+        - shardName: logical-shard01
+          physicalShard: shard01
+        - shardName: logical-shard02
+          physicalShard: shard01
+        - shardName: logical-shard03
+          physicalShard: shard01
+        - shardName: logical-shard04
+          physicalShard: shard02
+        - shardName: logical-shard05
+          physicalShard: shard02

--- a/pkg/redis/redis_shard_test.go
+++ b/pkg/redis/redis_shard_test.go
@@ -32,7 +32,7 @@ func TestNewRedisServerFromConnectionString(t *testing.T) {
 			},
 			want: &RedisServer{
 				Name:     "test",
-				IP:       "127.0.0.1",
+				Host:     "127.0.0.1",
 				Port:     "3333",
 				Role:     client.Unknown,
 				ReadOnly: false,
@@ -190,7 +190,7 @@ func TestRedisServer_Discover(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			srv := &RedisServer{
 				Name:     tt.fields.Name,
-				IP:       tt.fields.IP,
+				Host:     tt.fields.IP,
 				Port:     tt.fields.Port,
 				Role:     tt.fields.Role,
 				ReadOnly: tt.fields.ReadOnly,
@@ -229,7 +229,7 @@ func TestNewShard(t *testing.T) {
 				Servers: []RedisServer{
 					{
 						Name:     "redis://127.0.0.1:1000",
-						IP:       "127.0.0.1",
+						Host:     "127.0.0.1",
 						Port:     "1000",
 						Role:     client.Unknown,
 						ReadOnly: false,
@@ -237,7 +237,7 @@ func TestNewShard(t *testing.T) {
 					},
 					{
 						Name:     "redis://127.0.0.1:2000",
-						IP:       "127.0.0.1",
+						Host:     "127.0.0.1",
 						Port:     "2000",
 						Role:     client.Unknown,
 						ReadOnly: false,
@@ -245,7 +245,7 @@ func TestNewShard(t *testing.T) {
 					},
 					{
 						Name:     "redis://127.0.0.1:3000",
-						IP:       "127.0.0.1",
+						Host:     "127.0.0.1",
 						Port:     "3000",
 						Role:     client.Unknown,
 						ReadOnly: false,
@@ -301,7 +301,7 @@ func TestShard_Discover(t *testing.T) {
 				Servers: []RedisServer{
 					{
 						Name:     "redis://127.0.0.1:1000",
-						IP:       "127.0.0.1",
+						Host:     "127.0.0.1",
 						Port:     "1000",
 						Role:     client.Unknown,
 						ReadOnly: false,
@@ -322,7 +322,7 @@ func TestShard_Discover(t *testing.T) {
 					},
 					{
 						Name:     "redis://127.0.0.1:2000",
-						IP:       "127.0.0.1",
+						Host:     "127.0.0.1",
 						Port:     "2000",
 						Role:     client.Unknown,
 						ReadOnly: false,
@@ -342,7 +342,7 @@ func TestShard_Discover(t *testing.T) {
 						)},
 					{
 						Name:     "redis://127.0.0.1:3000",
-						IP:       "127.0.0.1",
+						Host:     "127.0.0.1",
 						Port:     "3000",
 						Role:     client.Unknown,
 						ReadOnly: false,
@@ -372,7 +372,7 @@ func TestShard_Discover(t *testing.T) {
 				Servers: []RedisServer{
 					{
 						Name:     "redis://127.0.0.1:1000",
-						IP:       "127.0.0.1",
+						Host:     "127.0.0.1",
 						Port:     "1000",
 						Role:     client.Unknown,
 						ReadOnly: false,
@@ -393,7 +393,7 @@ func TestShard_Discover(t *testing.T) {
 					},
 					{
 						Name:     "redis://127.0.0.1:2000",
-						IP:       "127.0.0.1",
+						Host:     "127.0.0.1",
 						Port:     "2000",
 						Role:     client.Unknown,
 						ReadOnly: false,
@@ -407,7 +407,7 @@ func TestShard_Discover(t *testing.T) {
 						)},
 					{
 						Name:     "redis://127.0.0.1:3000",
-						IP:       "127.0.0.1",
+						Host:     "127.0.0.1",
 						Port:     "3000",
 						Role:     client.Unknown,
 						ReadOnly: false,
@@ -437,7 +437,7 @@ func TestShard_Discover(t *testing.T) {
 				Servers: []RedisServer{
 					{
 						Name:     "redis://127.0.0.1:1000",
-						IP:       "127.0.0.1",
+						Host:     "127.0.0.1",
 						Port:     "1000",
 						Role:     client.Unknown,
 						ReadOnly: false,
@@ -458,7 +458,7 @@ func TestShard_Discover(t *testing.T) {
 					},
 					{
 						Name:     "redis://127.0.0.1:2000",
-						IP:       "127.0.0.1",
+						Host:     "127.0.0.1",
 						Port:     "2000",
 						Role:     client.Unknown,
 						ReadOnly: false,
@@ -479,7 +479,7 @@ func TestShard_Discover(t *testing.T) {
 					},
 					{
 						Name:     "redis://127.0.0.1:3000",
-						IP:       "127.0.0.1",
+						Host:     "127.0.0.1",
 						Port:     "3000",
 						Role:     client.Unknown,
 						ReadOnly: false,
@@ -540,7 +540,7 @@ func TestShard_Init(t *testing.T) {
 				Servers: []RedisServer{
 					{
 						Name:     "redis://127.0.0.1:1000",
-						IP:       "127.0.0.1",
+						Host:     "127.0.0.1",
 						Port:     "1000",
 						Role:     client.Unknown,
 						ReadOnly: false,
@@ -559,7 +559,7 @@ func TestShard_Init(t *testing.T) {
 					},
 					{
 						Name:     "redis://127.0.0.1:2000",
-						IP:       "127.0.0.1",
+						Host:     "127.0.0.1",
 						Port:     "2000",
 						Role:     client.Unknown,
 						ReadOnly: false,
@@ -577,7 +577,7 @@ func TestShard_Init(t *testing.T) {
 						)},
 					{
 						Name:     "redis://127.0.0.1:3000",
-						IP:       "127.0.0.1",
+						Host:     "127.0.0.1",
 						Port:     "3000",
 						Role:     client.Unknown,
 						ReadOnly: false,
@@ -606,7 +606,7 @@ func TestShard_Init(t *testing.T) {
 				Servers: []RedisServer{
 					{
 						Name:     "redis://127.0.0.1:1000",
-						IP:       "127.0.0.1",
+						Host:     "127.0.0.1",
 						Port:     "1000",
 						Role:     client.Unknown,
 						ReadOnly: false,
@@ -625,7 +625,7 @@ func TestShard_Init(t *testing.T) {
 					},
 					{
 						Name:     "redis://127.0.0.1:2000",
-						IP:       "127.0.0.1",
+						Host:     "127.0.0.1",
 						Port:     "2000",
 						Role:     client.Unknown,
 						ReadOnly: false,
@@ -643,7 +643,7 @@ func TestShard_Init(t *testing.T) {
 						)},
 					{
 						Name:     "redis://127.0.0.1:3000",
-						IP:       "127.0.0.1",
+						Host:     "127.0.0.1",
 						Port:     "3000",
 						Role:     client.Unknown,
 						ReadOnly: false,
@@ -672,7 +672,7 @@ func TestShard_Init(t *testing.T) {
 				Servers: []RedisServer{
 					{
 						Name:     "redis://127.0.0.1:1000",
-						IP:       "127.0.0.1",
+						Host:     "127.0.0.1",
 						Port:     "1000",
 						Role:     client.Unknown,
 						ReadOnly: false,
@@ -736,7 +736,7 @@ func TestNewShardedCluster(t *testing.T) {
 					Servers: []RedisServer{
 						{
 							Name:     "redis://127.0.0.1:1000",
-							IP:       "127.0.0.1",
+							Host:     "127.0.0.1",
 							Port:     "1000",
 							Role:     client.Unknown,
 							ReadOnly: false,
@@ -744,7 +744,7 @@ func TestNewShardedCluster(t *testing.T) {
 						},
 						{
 							Name:     "redis://127.0.0.1:2000",
-							IP:       "127.0.0.1",
+							Host:     "127.0.0.1",
 							Port:     "2000",
 							Role:     client.Unknown,
 							ReadOnly: false,
@@ -757,7 +757,7 @@ func TestNewShardedCluster(t *testing.T) {
 					Servers: []RedisServer{
 						{
 							Name:     "redis://127.0.0.1:3000",
-							IP:       "127.0.0.1",
+							Host:     "127.0.0.1",
 							Port:     "3000",
 							Role:     client.Unknown,
 							ReadOnly: false,
@@ -765,7 +765,7 @@ func TestNewShardedCluster(t *testing.T) {
 						},
 						{
 							Name:     "redis://127.0.0.1:4000",
-							IP:       "127.0.0.1",
+							Host:     "127.0.0.1",
 							Port:     "4000",
 							Role:     client.Unknown,
 							ReadOnly: false,
@@ -826,7 +826,7 @@ func TestShardedCluster_Discover(t *testing.T) {
 					Servers: []RedisServer{
 						{
 							Name:     "redis://127.0.0.1:1000",
-							IP:       "127.0.0.1",
+							Host:     "127.0.0.1",
 							Port:     "1000",
 							Role:     client.Unknown,
 							ReadOnly: false,
@@ -845,7 +845,7 @@ func TestShardedCluster_Discover(t *testing.T) {
 					Servers: []RedisServer{
 						{
 							Name:     "redis://127.0.0.1:3000",
-							IP:       "127.0.0.1",
+							Host:     "127.0.0.1",
 							Port:     "3000",
 							Role:     client.Unknown,
 							ReadOnly: false,
@@ -871,7 +871,7 @@ func TestShardedCluster_Discover(t *testing.T) {
 					Servers: []RedisServer{
 						{
 							Name:     "redis://127.0.0.1:1000",
-							IP:       "127.0.0.1",
+							Host:     "127.0.0.1",
 							Port:     "1000",
 							Role:     client.Unknown,
 							ReadOnly: false,
@@ -888,7 +888,7 @@ func TestShardedCluster_Discover(t *testing.T) {
 					Servers: []RedisServer{
 						{
 							Name:     "redis://127.0.0.1:3000",
-							IP:       "127.0.0.1",
+							Host:     "127.0.0.1",
 							Port:     "3000",
 							Role:     client.Unknown,
 							ReadOnly: false,
@@ -961,7 +961,7 @@ func TestShardedCluster_GetShardByName(t *testing.T) {
 					Servers: []RedisServer{
 						{
 							Name:     "redis://127.0.0.1:1000",
-							IP:       "127.0.0.1",
+							Host:     "127.0.0.1",
 							Port:     "1000",
 							Role:     client.Unknown,
 							ReadOnly: false,
@@ -974,7 +974,7 @@ func TestShardedCluster_GetShardByName(t *testing.T) {
 					Servers: []RedisServer{
 						{
 							Name:     "redis://127.0.0.1:2000",
-							IP:       "127.0.0.1",
+							Host:     "127.0.0.1",
 							Port:     "3000",
 							Role:     client.Unknown,
 							ReadOnly: false,
@@ -991,7 +991,7 @@ func TestShardedCluster_GetShardByName(t *testing.T) {
 				Servers: []RedisServer{
 					{
 						Name:     "redis://127.0.0.1:2000",
-						IP:       "127.0.0.1",
+						Host:     "127.0.0.1",
 						Port:     "3000",
 						Role:     client.Unknown,
 						ReadOnly: false,
@@ -1013,6 +1013,57 @@ func TestShardedCluster_GetShardByName(t *testing.T) {
 		t.Run(tt.name, func(t *testing.T) {
 			if diff := deep.Equal(tt.sc.GetShardByName(tt.args.name), tt.want); len(diff) > 0 {
 				t.Errorf("ShardedCluster.GetShardByName() got diff: %v", diff)
+			}
+		})
+	}
+}
+
+func TestRedisServer_IP(t *testing.T) {
+	type fields struct {
+		Name     string
+		Host     string
+		Port     string
+		Role     client.Role
+		ReadOnly bool
+		CRUD     *crud.CRUD
+	}
+	tests := []struct {
+		name    string
+		fields  fields
+		want    string
+		wantErr bool
+	}{
+		{
+			name: "Returns the IP",
+			fields: fields{
+				Name:     "test",
+				Host:     "10.0.0.0",
+				Port:     "3333",
+				Role:     "",
+				ReadOnly: false,
+				CRUD:     &crud.CRUD{},
+			},
+			want:    "10.0.0.0",
+			wantErr: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			rs := &RedisServer{
+				Name:     tt.fields.Name,
+				Host:     tt.fields.Host,
+				Port:     tt.fields.Port,
+				Role:     tt.fields.Role,
+				ReadOnly: tt.fields.ReadOnly,
+				CRUD:     tt.fields.CRUD,
+			}
+			got, err := rs.IP()
+			if (err != nil) != tt.wantErr {
+				t.Errorf("RedisServer.IP() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if got != tt.want {
+				t.Errorf("RedisServer.IP() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/pkg/redis/sentinel_test.go
+++ b/pkg/redis/sentinel_test.go
@@ -28,7 +28,7 @@ var (
 			Servers: []RedisServer{
 				{
 					Name:     "shard00-0",
-					IP:       "127.0.0.1",
+					Host:     "127.0.0.1",
 					Port:     "2000",
 					Role:     redis.Master,
 					ReadOnly: false,
@@ -36,7 +36,7 @@ var (
 				},
 				{
 					Name:     "shard00-1",
-					IP:       "127.0.0.1",
+					Host:     "127.0.0.1",
 					Port:     "2001",
 					Role:     redis.Slave,
 					ReadOnly: true,
@@ -44,7 +44,7 @@ var (
 				},
 				{
 					Name:     "shard00-2",
-					IP:       "127.0.0.1",
+					Host:     "127.0.0.1",
 					Port:     "2002",
 					Role:     redis.Slave,
 					ReadOnly: true,
@@ -57,7 +57,7 @@ var (
 			Servers: []RedisServer{
 				{
 					Name:     "shard01-0",
-					IP:       "127.0.0.1",
+					Host:     "127.0.0.1",
 					Port:     "3000",
 					Role:     redis.Master,
 					ReadOnly: false,
@@ -65,7 +65,7 @@ var (
 				},
 				{
 					Name:     "shard01-1",
-					IP:       "127.0.0.1",
+					Host:     "127.0.0.1",
 					Port:     "3001",
 					Role:     redis.Slave,
 					ReadOnly: true,
@@ -73,7 +73,7 @@ var (
 				},
 				{
 					Name:     "shard01-2",
-					IP:       "127.0.0.1",
+					Host:     "127.0.0.1",
 					Port:     "3002",
 					Role:     redis.Slave,
 					ReadOnly: true,
@@ -86,7 +86,7 @@ var (
 			Servers: []RedisServer{
 				{
 					Name:     "shard02-0",
-					IP:       "127.0.0.1",
+					Host:     "127.0.0.1",
 					Port:     "4000",
 					Role:     redis.Master,
 					ReadOnly: false,
@@ -94,7 +94,7 @@ var (
 				},
 				{
 					Name:     "shard02-1",
-					IP:       "127.0.0.1",
+					Host:     "127.0.0.1",
 					Port:     "4001",
 					Role:     redis.Slave,
 					ReadOnly: true,
@@ -102,7 +102,7 @@ var (
 				},
 				{
 					Name:     "shard02-2",
-					IP:       "127.0.0.1",
+					Host:     "127.0.0.1",
 					Port:     "4002",
 					Role:     redis.Slave,
 					ReadOnly: true,
@@ -829,7 +829,7 @@ func TestSentinelServer_Monitor(t *testing.T) {
 					Servers: []RedisServer{
 						{
 							Name:     "shard00-0",
-							IP:       "127.0.0.1",
+							Host:     "127.0.0.1",
 							Port:     "2000",
 							Role:     redis.Slave,
 							ReadOnly: true,
@@ -837,7 +837,7 @@ func TestSentinelServer_Monitor(t *testing.T) {
 						},
 						{
 							Name:     "shard00-1",
-							IP:       "127.0.0.1",
+							Host:     "127.0.0.1",
 							Port:     "2001",
 							Role:     redis.Slave,
 							ReadOnly: true,
@@ -845,7 +845,7 @@ func TestSentinelServer_Monitor(t *testing.T) {
 						},
 						{
 							Name:     "shard00-2",
-							IP:       "127.0.0.1",
+							Host:     "127.0.0.1",
 							Port:     "2002",
 							Role:     redis.Slave,
 							ReadOnly: true,
@@ -1261,7 +1261,7 @@ func TestSentinelPool_Monitor(t *testing.T) {
 					Servers: []RedisServer{
 						{
 							Name:     "shard00-0",
-							IP:       "127.0.0.1",
+							Host:     "127.0.0.1",
 							Port:     "2000",
 							Role:     redis.Master,
 							ReadOnly: false,
@@ -1269,7 +1269,7 @@ func TestSentinelPool_Monitor(t *testing.T) {
 						},
 						{
 							Name:     "shard00-1",
-							IP:       "127.0.0.1",
+							Host:     "127.0.0.1",
 							Port:     "2001",
 							Role:     redis.Slave,
 							ReadOnly: true,
@@ -1277,7 +1277,7 @@ func TestSentinelPool_Monitor(t *testing.T) {
 						},
 						{
 							Name:     "shard00-2",
-							IP:       "127.0.0.1",
+							Host:     "127.0.0.1",
 							Port:     "2002",
 							Role:     redis.Slave,
 							ReadOnly: true,
@@ -1372,7 +1372,7 @@ func TestSentinelPool_Monitor(t *testing.T) {
 					Servers: []RedisServer{
 						{
 							Name:     "shard00-0",
-							IP:       "127.0.0.1",
+							Host:     "127.0.0.1",
 							Port:     "2000",
 							Role:     redis.Master,
 							ReadOnly: false,
@@ -1380,7 +1380,7 @@ func TestSentinelPool_Monitor(t *testing.T) {
 						},
 						{
 							Name:     "shard00-1",
-							IP:       "127.0.0.1",
+							Host:     "127.0.0.1",
 							Port:     "2001",
 							Role:     redis.Slave,
 							ReadOnly: true,
@@ -1388,7 +1388,7 @@ func TestSentinelPool_Monitor(t *testing.T) {
 						},
 						{
 							Name:     "shard00-2",
-							IP:       "127.0.0.1",
+							Host:     "127.0.0.1",
 							Port:     "2002",
 							Role:     redis.Slave,
 							ReadOnly: true,
@@ -1460,7 +1460,7 @@ func TestSentinelPool_Monitor(t *testing.T) {
 					Servers: []RedisServer{
 						{
 							Name:     "shard00-0",
-							IP:       "127.0.0.1",
+							Host:     "127.0.0.1",
 							Port:     "2000",
 							Role:     redis.Master,
 							ReadOnly: false,
@@ -1468,7 +1468,7 @@ func TestSentinelPool_Monitor(t *testing.T) {
 						},
 						{
 							Name:     "shard00-1",
-							IP:       "127.0.0.1",
+							Host:     "127.0.0.1",
 							Port:     "2001",
 							Role:     redis.Slave,
 							ReadOnly: true,
@@ -1476,7 +1476,7 @@ func TestSentinelPool_Monitor(t *testing.T) {
 						},
 						{
 							Name:     "shard00-2",
-							IP:       "127.0.0.1",
+							Host:     "127.0.0.1",
 							Port:     "2002",
 							Role:     redis.Slave,
 							ReadOnly: true,


### PR DESCRIPTION
* Adds an example of a backend environment that can be run in Kind
* Adds the option to configure redis using DNS records in the Sentinel custom resource. This feature is only meant for testing purposes, to avoid having to configure the specific IPs of the redis Pods in the Sentinel resource. Should not be used in production.

/kind feature
/kind documentation
/priority important-soon
/assign