### PR TITLE
Do not pass the schema as argument to ReconcileOwnedResources

### DIFF
--- a/controllers/autossl_controller.go
+++ b/controllers/autossl_controller.go
@@ -87,7 +87,7 @@ func (r *AutoSSLReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	}
 	resources = append(resources, workload...)
 
-	err = r.ReconcileOwnedResources(ctx, instance, r.GetScheme(), resources)
+	err = r.ReconcileOwnedResources(ctx, instance, resources)
 	if err != nil {
 		log.Error(err, "unable to update owned resources")
 		return r.ManageError(ctx, instance, err)

--- a/controllers/backend_controller.go
+++ b/controllers/backend_controller.go
@@ -107,7 +107,7 @@ func (r *BackendReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	resources = append(resources, cron_resources...)
 
 	// Reconcile all resources
-	err = r.ReconcileOwnedResources(ctx, instance, r.GetScheme(), resources)
+	err = r.ReconcileOwnedResources(ctx, instance, resources)
 	if err != nil {
 		log.Error(err, "unable to reconcile owned resources")
 		return r.ManageError(ctx, instance, err)

--- a/controllers/corsproxy_controller.go
+++ b/controllers/corsproxy_controller.go
@@ -83,7 +83,7 @@ func (r *CORSProxyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	}
 	resources = append(resources, workload...)
 
-	err = r.ReconcileOwnedResources(ctx, instance, r.GetScheme(), resources)
+	err = r.ReconcileOwnedResources(ctx, instance, resources)
 	if err != nil {
 		log.Error(err, "unable to reconcile owned resources")
 		return r.ManageError(ctx, instance, err)

--- a/controllers/echoapi_controller.go
+++ b/controllers/echoapi_controller.go
@@ -72,7 +72,7 @@ func (r *EchoAPIReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		return r.ManageError(ctx, instance, err)
 	}
 
-	err = r.ReconcileOwnedResources(ctx, instance, r.GetScheme(), resources)
+	err = r.ReconcileOwnedResources(ctx, instance, resources)
 	if err != nil {
 		log.Error(err, "unable to update owned resources")
 		return r.ManageError(ctx, instance, err)

--- a/controllers/mappingservice_controller.go
+++ b/controllers/mappingservice_controller.go
@@ -85,7 +85,7 @@ func (r *MappingServiceReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	}
 	resources = append(resources, workload...)
 
-	err = r.ReconcileOwnedResources(ctx, instance, r.GetScheme(), resources)
+	err = r.ReconcileOwnedResources(ctx, instance, resources)
 	if err != nil {
 		log.Error(err, "unable to reconcile owned resources")
 		return r.ManageError(ctx, instance, err)

--- a/controllers/redisshard_controller.go
+++ b/controllers/redisshard_controller.go
@@ -70,7 +70,7 @@ func (r *RedisShardReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 		instance.Spec,
 	)
 
-	if err := r.ReconcileOwnedResources(ctx, instance, r.GetScheme(), gen.Resources()); err != nil {
+	if err := r.ReconcileOwnedResources(ctx, instance, gen.Resources()); err != nil {
 		log.Error(err, "unable to update owned resources")
 		return r.ManageError(ctx, instance, err)
 	}

--- a/controllers/sentinel_controller.go
+++ b/controllers/sentinel_controller.go
@@ -80,7 +80,7 @@ func (r *SentinelReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		instance.Spec,
 	)
 
-	if err := r.ReconcileOwnedResources(ctx, instance, r.GetScheme(), gen.Resources()); err != nil {
+	if err := r.ReconcileOwnedResources(ctx, instance, gen.Resources()); err != nil {
 		log.Error(err, "unable to update owned resources")
 		return r.ManageError(ctx, instance, err)
 	}

--- a/controllers/zync_controller.go
+++ b/controllers/zync_controller.go
@@ -90,7 +90,7 @@ func (r *ZyncReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 	resources = append(resources, que_resources...)
 
 	// Reconcile all resources
-	err = r.ReconcileOwnedResources(ctx, instance, r.GetScheme(), resources)
+	err = r.ReconcileOwnedResources(ctx, instance, resources)
 	if err != nil {
 		log.Error(err, "unable to reconcile owned resources")
 		return r.ManageError(ctx, instance, err)

--- a/pkg/reconcilers/basereconciler/v2/reconciler.go
+++ b/pkg/reconcilers/basereconciler/v2/reconciler.go
@@ -113,8 +113,7 @@ func (r *Reconciler) ManageCleanUpLogic(instance client.Object, fns []func(), lo
 
 // ReconcileOwnedResources handles generalized resource reconcile logic for
 // all controllers
-func (r *Reconciler) ReconcileOwnedResources(ctx context.Context, owner client.Object,
-	scheme *runtime.Scheme, resources []Resource) error {
+func (r *Reconciler) ReconcileOwnedResources(ctx context.Context, owner client.Object, resources []Resource) error {
 
 	lr := make([]lockedresource.LockedResource, 0, len(resources))
 
@@ -126,7 +125,7 @@ func (r *Reconciler) ReconcileOwnedResources(ctx context.Context, owner client.O
 				return err
 			}
 
-			if err := controllerutil.SetControllerReference(owner, object, scheme); err != nil {
+			if err := controllerutil.SetControllerReference(owner, object, r.GetScheme()); err != nil {
 				return err
 			}
 

--- a/pkg/reconcilers/basereconciler/v2/test/test_controller.go
+++ b/pkg/reconcilers/basereconciler/v2/test/test_controller.go
@@ -58,7 +58,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 		return *result, err
 	}
 
-	err = r.ReconcileOwnedResources(ctx, instance, r.GetScheme(), []basereconciler.Resource{
+	err = r.ReconcileOwnedResources(ctx, instance, []basereconciler.Resource{
 		resources.DeploymentTemplate{
 			Template: deployment(req.Namespace, instance.Spec.Marin3r),
 			RolloutTriggers: []resources.RolloutTrigger{{

--- a/pkg/reconcilers/workloads/test/test_controller.go
+++ b/pkg/reconcilers/workloads/test/test_controller.go
@@ -86,7 +86,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 	}
 
 	// Reconcile all resources
-	err = r.ReconcileOwnedResources(ctx, instance, r.GetScheme(), deployments)
+	err = r.ReconcileOwnedResources(ctx, instance, deployments)
 	if err != nil {
 		log.Error(err, "unable to reconcile owned resources")
 		return r.ManageError(ctx, instance, err)


### PR DESCRIPTION
The scheme is already part of the reconciler, so there is no need of
passing it to the function, which is itself a method of the reconciler.
This is probably something that was left from an older implementation.

/kind cleanup
/priority important-longterm
/assign