### PR TITLE
Hardcode the name of the container for all controllers

### DIFF
--- a/pkg/generators/autossl/deployment.go
+++ b/pkg/generators/autossl/deployment.go
@@ -49,7 +49,7 @@ func (gen *Generator) deployment() func() *appsv1.Deployment {
 						}(),
 						Containers: []corev1.Container{
 							{
-								Name:  gen.GetComponent(),
+								Name:  "autossl",
 								Image: fmt.Sprintf("%s:%s", *gen.Spec.Image.Name, *gen.Spec.Image.Tag),
 								Ports: pod.ContainerPorts(
 									pod.ContainerPortTCP("http", 8081),

--- a/pkg/generators/corsproxy/deployment.go
+++ b/pkg/generators/corsproxy/deployment.go
@@ -35,7 +35,7 @@ func (gen *Generator) deployment() func() *appsv1.Deployment {
 						}(),
 						Containers: []corev1.Container{
 							{
-								Name:  gen.GetComponent(),
+								Name:  "cors-proxy",
 								Image: fmt.Sprintf("%s:%s", *gen.Spec.Image.Name, *gen.Spec.Image.Tag),
 								Ports: pod.ContainerPorts(
 									pod.ContainerPortTCP("http", 8080),

--- a/pkg/generators/echoapi/deployment.go
+++ b/pkg/generators/echoapi/deployment.go
@@ -36,7 +36,7 @@ func (gen *Generator) deployment() func() *appsv1.Deployment {
 						}(),
 						Containers: []corev1.Container{
 							{
-								Name:  gen.GetComponent(),
+								Name:  "echo-api",
 								Image: fmt.Sprintf("%s:%s", *gen.Spec.Image.Name, *gen.Spec.Image.Tag),
 								Ports: pod.ContainerPorts(
 									pod.ContainerPortTCP("http", 9292),

--- a/pkg/generators/mappingservice/deployment.go
+++ b/pkg/generators/mappingservice/deployment.go
@@ -35,7 +35,7 @@ func (gen *Generator) deployment() func() *appsv1.Deployment {
 						}(),
 						Containers: []corev1.Container{
 							{
-								Name:  gen.GetComponent(),
+								Name:  "mapping-service",
 								Image: fmt.Sprintf("%s:%s", *gen.Spec.Image.Name, *gen.Spec.Image.Tag),
 								Ports: pod.ContainerPorts(
 									pod.ContainerPortTCP("mapping", 8093),

--- a/pkg/generators/zync/api_deployment.go
+++ b/pkg/generators/zync/api_deployment.go
@@ -36,7 +36,7 @@ func (gen *APIGenerator) deployment() func() *appsv1.Deployment {
 						}(),
 						Containers: []corev1.Container{
 							{
-								Name:  "zync-api",
+								Name:  "zync",
 								Image: fmt.Sprintf("%s:%s", *gen.Image.Name, *gen.Image.Tag),
 								Ports: pod.ContainerPorts(
 									pod.ContainerPortTCP("http", 8080),

--- a/pkg/generators/zync/api_deployment.go
+++ b/pkg/generators/zync/api_deployment.go
@@ -36,7 +36,7 @@ func (gen *APIGenerator) deployment() func() *appsv1.Deployment {
 						}(),
 						Containers: []corev1.Container{
 							{
-								Name:  gen.GetComponent(),
+								Name:  "zync-api",
 								Image: fmt.Sprintf("%s:%s", *gen.Image.Name, *gen.Image.Tag),
 								Ports: pod.ContainerPorts(
 									pod.ContainerPortTCP("http", 8080),

--- a/pkg/generators/zync/que_deployment.go
+++ b/pkg/generators/zync/que_deployment.go
@@ -37,7 +37,7 @@ func (gen *QueGenerator) deployment() func() *appsv1.Deployment {
 						}(),
 						Containers: []corev1.Container{
 							{
-								Name:  gen.GetComponent(),
+								Name:  "zync-que",
 								Image: fmt.Sprintf("%s:%s", *gen.Image.Name, *gen.Image.Tag),
 								Command: []string{
 									"/usr/bin/bash",


### PR DESCRIPTION
The name of the containers within the Pod should not be dependant on the name of the component (which changes in the case of canary Deployments for example). This is important as the shutdown manager features in marin3r depend on the name of the containers being always the same. See https://github.com/3scale/3scale-saas/blob/4c71ea98147891dfb147ef4bd4bebe038b1abe1a/manifests/stg-saas/ocp4/3scale-saas/echo-api/stg-saas-echo-api.yaml#L38 as an example of this.

/kind bug
/priority important-soon
/assign