### PR TITLE
feat: Improve workload checks

### DIFF
--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -75,8 +75,6 @@ func checkWorkloadResources(dep *appsv1.Deployment, ew expectedWorkload) func() 
 			}),
 		)
 
-		Expect(dep.Spec.Replicas).To(Equal(pointer.Int32Ptr(ew.Replicas)))
-
 		if ew.ContainerName != "" {
 			Expect(dep.Spec.Template.Spec.Containers[0].Name).To(Equal(ew.ContainerName))
 		}
@@ -103,6 +101,9 @@ func checkWorkloadResources(dep *appsv1.Deployment, ew expectedWorkload) func() 
 		if ew.HPA {
 			Expect(hpa.Spec.ScaleTargetRef.Kind).Should(Equal("Deployment"))
 			Expect(hpa.Spec.ScaleTargetRef.Name).Should(Equal(ew.Name))
+			Expect(hpa.Spec.MinReplicas).Should(Equal(pointer.Int32Ptr(ew.Replicas)))
+		} else {
+			Expect(dep.Spec.Replicas).To(Equal(pointer.Int32Ptr(ew.Replicas)))
 		}
 
 		pdb := &policyv1beta1.PodDisruptionBudget{}

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -54,6 +54,7 @@ type expectedWorkload struct {
 	Replicas       int32
 	ContainerName  string
 	ContainerImage string
+	ContainterCmd  []string
 	ContainterArgs []string
 	HPA            bool
 	PDB            bool
@@ -82,6 +83,10 @@ func checkWorkloadResources(dep *appsv1.Deployment, ew expectedWorkload) func() 
 
 		if ew.ContainerImage != "" {
 			Expect(dep.Spec.Template.Spec.Containers[0].Image).To(Equal(ew.ContainerImage))
+		}
+
+		if ew.ContainterCmd != nil {
+			Expect(dep.Spec.Template.Spec.Containers[0].Command).To(Equal(ew.ContainterCmd))
 		}
 
 		if ew.ContainterArgs != nil {


### PR DESCRIPTION
- Adds a container command check.
- When the HPA is enabled, it ignores the Replica number and checks the HPA MinReplica instead.


/kind feature
/priority important-longterm
/assign