### PR TITLE
feat: env based logger configuration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -113,7 +113,7 @@ build: generate fmt vet assets ## Build manager binary.
 	go build -o bin/manager main.go
 
 run: manifests generate fmt vet assets ## Run a controller from your host.
-	go run ./main.go
+	LOG_MODE="development" go run ./main.go
 
 docker-build: ## Build docker image with the manager.
 	docker build -t ${IMG} .

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 0.13.1-alpha.4
+VERSION ?= 0.13.1-alpha.5
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ A Kubernetes Operator based on the Operator SDK to manage 3scale SaaS (hosted ve
 ## Documentation
 
 * [Getting started](docs/getting-started.md)
+* [Log configuration](docs/logging.md)
 * [Development](docs/development.md)
 * [Release](docs/release.md)
 

--- a/bundle/manifests/saas-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/saas-operator.clusterserviceversion.yaml
@@ -570,7 +570,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/3scale/saas-operator
     support: Red Hat
-  name: saas-operator.v0.13.1-alpha.4
+  name: saas-operator.v0.13.1-alpha.5
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -4357,7 +4357,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
-                image: quay.io/3scale/saas-operator:v0.13.1-alpha.4
+                image: quay.io/3scale/saas-operator:v0.13.1-alpha.5
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -4859,4 +4859,4 @@ spec:
   provider:
     name: Red Hat
     url: https://www.3scale.net/
-  version: 0.13.1-alpha.4
+  version: 0.13.1-alpha.5

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,4 +13,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/3scale/saas-operator
-  newTag: v0.13.1-alpha.4
+  newTag: v0.13.1-alpha.5

--- a/docs/logging.md
+++ b/docs/logging.md
@@ -1,0 +1,49 @@
+# Logging
+
+The 3scale SaaS operator uses the [go.uber.org/zap](https://pkg.go.dev/go.uber.org/zap) library for logs.
+
+## Configuration
+
+The operator logger supports the following environment variables:
+
+| Variable      | Format | Default    | Values                                                 |
+| ------------- | ------ | ---------- | ------------------------------------------------------ |
+| LOG_MODE      | string | production | `production` / `development`                           |
+| LOG_ENCODING  | string | -          | `json` / `console`                                     |
+| LOG_LEVEL     | string | -          | `debug`,`info`,`warn`,`error`,`dpanic`,`panic`,`fatal` |
+| LOG_VERBOSITY | int8   | 0          | `0-10`                                                 |
+
+### LOG_MODE
+
+Log mode defaults to `production` and that configures the logger with:
+- uses a JSON encoder
+- writes to standard error
+- enables sampling
+- Stacktraces are automatically included on logs of ErrorLevel and above.
+
+When set to `development`, it enables development mode:
+- uses a console encoder
+- writes to standard error
+- disables sampling
+- makes DPanicLevel logs panic
+- Stacktraces are automatically included on logs of WarnLevel and above.
+
+### LOG_ENCODING
+
+If not set, will be configured by `LOG_MODE` profile: `json` for `production` and `console` for `development`.
+
+Can be overrided by setting up the `LOG_ENCODING` variable.
+
+### LOG_LEVEL
+
+Defaults to `debug` in `development` mode and `info` for production.
+
+Can be overrided by setting up the `LOG_LEVEL` variable.
+
+More information in [zapcore#Level](https://pkg.go.dev/go.uber.org/zap@v1.21.0/zapcore#Level).
+
+### LOG_VERBOSITY
+
+If `LOG_LEVEL` is set to `debug`, via `LOG_LEVEL` or with `LOG_MODDE` set to `development`, allows increasing the log verbosity.
+
+Allows values from 1 to 10.

--- a/go.mod
+++ b/go.mod
@@ -18,6 +18,7 @@ require (
 	github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring v0.42.1
 	github.com/prometheus/client_golang v1.11.0
 	github.com/redhat-cop/operator-utils v1.3.1
+	go.uber.org/zap v1.17.0 // indirect
 	k8s.io/api v0.21.2
 	k8s.io/apimachinery v0.21.2
 	k8s.io/client-go v0.21.2

--- a/main.go
+++ b/main.go
@@ -40,7 +40,7 @@ import (
 	"github.com/3scale/saas-operator/controllers"
 	externalsecretsv1alpha1 "github.com/3scale/saas-operator/pkg/apis/externalsecrets/v1alpha1"
 	grafanav1alpha1 "github.com/3scale/saas-operator/pkg/apis/grafana/v1alpha1"
-	basereconciler_v2 "github.com/3scale/saas-operator/pkg/reconcilers/basereconciler/v2"
+	"github.com/3scale/saas-operator/pkg/reconcilers/basereconciler/v2"
 	"github.com/3scale/saas-operator/pkg/reconcilers/threads"
 	"github.com/3scale/saas-operator/pkg/reconcilers/workloads"
 	"github.com/3scale/saas-operator/pkg/util"
@@ -128,7 +128,7 @@ func main() {
 	/* BASERECONCILER_V2 BASED CONTROLLERS*/
 
 	if err = (&controllers.SentinelReconciler{
-		Reconciler:     basereconciler_v2.NewFromManager(mgr, mgr.GetEventRecorderFor("Sentinel"), false),
+		Reconciler:     basereconciler.NewFromManager(mgr, mgr.GetEventRecorderFor("Sentinel"), false),
 		SentinelEvents: threads.NewManager(),
 		Metrics:        threads.NewManager(),
 		Log:            ctrl.Log.WithName("controllers").WithName("Sentinel"),
@@ -137,14 +137,14 @@ func main() {
 		os.Exit(1)
 	}
 	if err = (&controllers.RedisShardReconciler{
-		Reconciler: basereconciler_v2.NewFromManager(mgr, mgr.GetEventRecorderFor("RedisShard"), false),
+		Reconciler: basereconciler.NewFromManager(mgr, mgr.GetEventRecorderFor("RedisShard"), false),
 		Log:        ctrl.Log.WithName("controllers").WithName("RedisShard"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "RedisShard")
 		os.Exit(1)
 	}
 	if err = (&controllers.TwemproxyConfigReconciler{
-		Reconciler:     basereconciler_v2.NewFromManager(mgr, mgr.GetEventRecorderFor("TwemproxyConfig"), false),
+		Reconciler:     basereconciler.NewFromManager(mgr, mgr.GetEventRecorderFor("TwemproxyConfig"), false),
 		SentinelEvents: threads.NewManager(),
 		Log:            ctrl.Log.WithName("controllers").WithName("TwemproxyConfig"),
 	}).SetupWithManager(mgr); err != nil {

--- a/main.go
+++ b/main.go
@@ -25,6 +25,7 @@ import (
 
 	// Import all Kubernetes client auth plugins (e.g. Azure, GCP, OIDC, etc.)
 	// to ensure that exec-entrypoint and run can make use of them.
+
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
@@ -34,7 +35,6 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/cache"
 	"sigs.k8s.io/controller-runtime/pkg/healthz"
-	"sigs.k8s.io/controller-runtime/pkg/log/zap"
 
 	saasv1alpha1 "github.com/3scale/saas-operator/api/v1alpha1"
 	"github.com/3scale/saas-operator/controllers"
@@ -54,6 +54,7 @@ const (
 	// which specifies the Namespace to watch.
 	// An empty value means the operator is running with cluster scope.
 	watchNamespaceEnvVar string = "WATCH_NAMESPACE"
+	debugLevelEnvVar     string = "DEBUG_LEVEL"
 )
 
 var (
@@ -80,13 +81,8 @@ func main() {
 	flag.BoolVar(&enableLeaderElection, "leader-elect", false,
 		"Enable leader election for controller manager. "+
 			"Enabling this will ensure there is only one active controller manager.")
-	opts := zap.Options{
-		Development: true,
-	}
-	opts.BindFlags(flag.CommandLine)
-	flag.Parse()
 
-	ctrl.SetLogger(zap.New(zap.UseFlagOptions(&opts)))
+	ctrl.SetLogger((util.Logger{}).New())
 
 	printVersion()
 

--- a/pkg/util/logger.go
+++ b/pkg/util/logger.go
@@ -1,0 +1,66 @@
+package util
+
+import (
+	"flag"
+	"fmt"
+	"os"
+
+	"github.com/go-logr/logr"
+	"github.com/kelseyhightower/envconfig"
+	uzap "go.uber.org/zap"
+	"go.uber.org/zap/zapcore"
+	"sigs.k8s.io/controller-runtime/pkg/log/zap"
+)
+
+type Logger struct {
+	cfg LogConfig
+}
+
+type LogConfig struct {
+	LogMode      string `envconfig:"LOG_MODE"`
+	LogEncoding  string `envconfig:"LOG_ENCODING"`
+	LogLevel     string `envconfig:"LOG_LEVEL"`
+	LogVerbosity int8   `envconfig:"LOG_VERBOSITY" default:"0"`
+}
+
+// New will return a Logger configured with the LOG_* environment variables
+// and the supported --zap* flags passed to the operator command line
+func (l Logger) New() logr.Logger {
+
+	if err := envconfig.Process("log", &l.cfg); err != nil {
+		fmt.Fprintf(os.Stderr, "unable to get log env variables")
+	}
+
+	opts := zap.Options{}
+
+	// Development configures the logger to use a Zap development config
+	// (stacktraces on warnings, no sampling), otherwise a Zap production
+	// config will be used (stacktraces on errors, sampling).
+	opts.Development = (l.cfg.LogMode != "production")
+
+	// Encoder configures how Zap will encode the output.  Defaults to
+	// console when Development is true and JSON otherwise
+	switch string(l.cfg.LogEncoding) {
+	case "json", "JSON":
+		opts.Encoder = zapcore.NewJSONEncoder(uzap.NewDevelopmentEncoderConfig())
+	case "console", "CONSOLE":
+		opts.Encoder = zapcore.NewConsoleEncoder(uzap.NewDevelopmentEncoderConfig())
+	}
+
+	// Log level
+	lvl := zapcore.Level(l.cfg.LogVerbosity)
+	if err := lvl.UnmarshalText([]byte(l.cfg.LogLevel)); err != nil && l.cfg.LogLevel != "" {
+		fmt.Fprint(os.Stderr, err.Error())
+	}
+
+	// Level configures the verbosity of the logging when level is Debug
+	if lvl.Get() == zapcore.DebugLevel && l.cfg.LogVerbosity > 0 {
+		opts.Level = zapcore.Level(0 - l.cfg.LogVerbosity)
+	}
+
+	// Allow also commandline based log configuration
+	opts.BindFlags(flag.CommandLine)
+	flag.Parse()
+
+	return zap.New(zap.UseFlagOptions(&opts))
+}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,7 +1,7 @@
 package version
 
 const (
-	version string = "v0.13.1-alpha.4"
+	version string = "v0.13.1-alpha.5"
 )
 
 // Current returns the current marin3r operator version


### PR DESCRIPTION
The 3scale SaaS operator uses the [go.uber.org/zap](https://pkg.go.dev/go.uber.org/zap) library for logs.

This PR allows configuring the logger based on environment variables:


| Variable      | Format | Default    | Values                                                 |
| ------------- | ------ | ---------- | ------------------------------------------------------ |
| LOG_MODE      | string | production | `production` / `development`                           |
| LOG_ENCODING  | string | -          | `json` / `console`                                     |
| LOG_LEVEL     | string | -          | `debug`,`info`,`warn`,`error`,`dpanic`,`panic`,`fatal` |
| LOG_VERBOSITY | int8   | 0          | `0-10`                                                 |

Defaults to `production` mode, with the following output:

```json
{"level":"info","ts":1648486615.3262627,"logger":"resource-reconciler.default/shard01.v1/Service/default/redis-shard-shard01","msg":"reconcile called for","object":"v1/Service/default/redis-shard-shard01","request":"default/redis-shard-shard01"}
{"level":"info","ts":1648486615.3261468,"logger":"controller-runtime.manager.controller.controller_locked_object_v1/ConfigMap/default/redis-config-shard01","msg":"Starting workers","worker count":1}
{"level":"info","ts":1648486615.3261518,"logger":"controller-runtime.manager.controller.controller_locked_object_v1/ConfigMap/default/redis-readiness-script-shard01","msg":"Starting workers","worker count":1}
{"level":"info","ts":1648486615.3263252,"logger":"resource-reconciler.default/shard01.v1/ConfigMap/default/redis-config-shard01","msg":"reconcile called for","object":"v1/ConfigMap/default/redis-config-shard01","request":"default/redis-config-shard01"}
{"level":"info","ts":1648486615.326344,"logger":"resource-reconciler.default/shard01.v1/ConfigMap/default/redis-readiness-script-shard01","msg":"reconcile called for","object":"v1/ConfigMap/default/redis-readiness-script-shard01","request":"default/redis-readiness-script-shard01"}
```

Also supports a `development` mode, with the following output:

```bash
2022-03-28T16:57:49.185Z        DEBUG   resource-reconciler.default/shard01.v1/ConfigMap/default/redis-readiness-script-shard01 determined that resources are equal
2022-03-28T16:57:49.185Z        DEBUG   resource-reconciler.default/shard01.v1/Service/default/redis-shard-shard01      determined that resources are equal
2022-03-28T16:57:49.186Z        DEBUG   resource-reconciler.default/shard01.apps/v1/StatefulSet/default/redis-shard-shard01     determined that resources are equal
2022-03-28T16:57:49.885Z        INFO    controllers.RedisShard  waiting for redis shard init    {"name": "shard02", "namespace": "default"}
2022-03-28T16:57:49.885Z        INFO    controller-runtime.manager.controller.controller_locked_object_v1/Service/default/redis-shard-shard02   Starting EventSource    {"source": "kind source: /v1, Kind=Service"}
2022-03-28T16:57:49.885Z        INFO    controller-runtime.manager.controller.controller_locked_object_v1/Service/default/redis-shard-shard02   Starting EventSource    {"source": "channel source: 0xc000fc94f0"}
2022-03-28T16:57:49.885Z        INFO    controller-runtime.manager.controller.controller_locked_object_v1/Service/default/redis-shard-shard02   Starting Controller
```

More details in [docs/logging.md](https://github.com/3scale-ops/saas-operator/blob/main/docs/logging.md)

/kind feature
/priority important-longterm
/assign
