### PR TITLE
Release v0.15.0

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 0.14.4-alpha.4
+VERSION ?= 0.15.0
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/bundle.Dockerfile
+++ b/bundle.Dockerfile
@@ -5,8 +5,9 @@ LABEL operators.operatorframework.io.bundle.mediatype.v1=registry+v1
 LABEL operators.operatorframework.io.bundle.manifests.v1=manifests/
 LABEL operators.operatorframework.io.bundle.metadata.v1=metadata/
 LABEL operators.operatorframework.io.bundle.package.v1=saas-operator
-LABEL operators.operatorframework.io.bundle.channels.v1=alpha
-LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.13.0+git
+LABEL operators.operatorframework.io.bundle.channels.v1=alpha,stable
+LABEL operators.operatorframework.io.bundle.channel.default.v1=alpha
+LABEL operators.operatorframework.io.metrics.builder=operator-sdk-v1.14.0+git
 LABEL operators.operatorframework.io.metrics.mediatype.v1=metrics+v1
 LABEL operators.operatorframework.io.metrics.project_layout=go.kubebuilder.io/v3
 

--- a/bundle/manifests/saas-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/saas-operator.clusterserviceversion.yaml
@@ -566,11 +566,11 @@ metadata:
     description: |-
       The 3scale SaaS Operator creates and maintains a SaaS-ready deployment
       of the Red Hat 3scale API Management on OpenShift.
-    operators.operatorframework.io/builder: operator-sdk-v1.13.0+git
+    operators.operatorframework.io/builder: operator-sdk-v1.14.0+git
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/3scale/saas-operator
     support: Red Hat
-  name: saas-operator.v0.14.4-alpha.4
+  name: saas-operator.v0.15.0
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -4367,7 +4367,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
-                image: quay.io/3scale/saas-operator:v0.14.4-alpha.4
+                image: quay.io/3scale/saas-operator:v0.15.0
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -4869,4 +4869,4 @@ spec:
   provider:
     name: Red Hat
     url: https://www.3scale.net/
-  version: 0.14.4-alpha.4
+  version: 0.15.0

--- a/bundle/metadata/annotations.yaml
+++ b/bundle/metadata/annotations.yaml
@@ -4,8 +4,9 @@ annotations:
   operators.operatorframework.io.bundle.manifests.v1: manifests/
   operators.operatorframework.io.bundle.metadata.v1: metadata/
   operators.operatorframework.io.bundle.package.v1: saas-operator
-  operators.operatorframework.io.bundle.channels.v1: alpha
-  operators.operatorframework.io.metrics.builder: operator-sdk-v1.13.0+git
+  operators.operatorframework.io.bundle.channels.v1: alpha,stable
+  operators.operatorframework.io.bundle.channel.default.v1: alpha
+  operators.operatorframework.io.metrics.builder: operator-sdk-v1.14.0+git
   operators.operatorframework.io.metrics.mediatype.v1: metrics+v1
   operators.operatorframework.io.metrics.project_layout: go.kubebuilder.io/v3
 

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,4 +13,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/3scale/saas-operator
-  newTag: v0.14.4-alpha.4
+  newTag: v0.15.0

--- a/docs/api-reference/reference.asciidoc
+++ b/docs/api-reference/reference.asciidoc
@@ -697,6 +697,7 @@ GrafanaDashboardSpec configures the Grafana Dashboard for the component
 - xref:{anchor_prefix}-github-com-3scale-saas-operator-api-v1alpha1-mappingservicespec[$$MappingServiceSpec$$]
 - xref:{anchor_prefix}-github-com-3scale-saas-operator-api-v1alpha1-sentinelspec[$$SentinelSpec$$]
 - xref:{anchor_prefix}-github-com-3scale-saas-operator-api-v1alpha1-systemspec[$$SystemSpec$$]
+- xref:{anchor_prefix}-github-com-3scale-saas-operator-api-v1alpha1-twemproxyconfigspec[$$TwemproxyConfigSpec$$]
 - xref:{anchor_prefix}-github-com-3scale-saas-operator-api-v1alpha1-zyncspec[$$ZyncSpec$$]
 ****
 
@@ -1855,6 +1856,7 @@ TwemproxyConfigSpec defines the desired state of TwemproxyConfig
 | *`sentinelURIs`* __string array__ | SentinelURI is the redis URI of sentinel. This is required as TewmproxyConfig will obtain the info about available redis servers from sentinel.
 | *`serverPools`* __xref:{anchor_prefix}-github-com-3scale-saas-operator-api-v1alpha1-twemproxyserverpool[$$TwemproxyServerPool$$] array__ | ServerPools is the list of Twemproxy server pools
 | *`reconcileServerPools`* __boolean__ | ReconcileServerPools is a flag that allows to deactivate the reconcile of the contents of the managed ConfigMap. This is useful in an emergency, to fix something manually. The re-sync logic will still work whenever the contents of the ConfigMap are changed, even if they are manually changed. This switch defaults to "true".
+| *`grafanaDashboard`* __xref:{anchor_prefix}-github-com-3scale-saas-operator-api-v1alpha1-grafanadashboardspec[$$GrafanaDashboardSpec$$]__ | Configures the Grafana Dashboard for the component
 |===
 
 

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,7 +1,7 @@
 package version
 
 const (
-	version string = "v0.14.4-alpha.4"
+	version string = "v0.15.0"
 )
 
 // Current returns the current marin3r operator version


### PR DESCRIPTION
Release v0.15.0 which includes https://github.com/3scale-ops/saas-operator/pull/202. I have increased the minor release number because it is an important change on how the operator works internally.

I have deployed an alpha release to staging to test that everything runs smoothly.