### PR TITLE
fix: Timeout waiting for process kube apisever to stop

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ IMG ?= $(IMAGE_TAG_BASE):v$(VERSION)
 CRD_OPTIONS ?= "crd:trivialVersions=true,preserveUnknownFields=false"
 # ENVTEST_K8S_VERSION refers to the version of kubebuilder assets to be downloaded by envtest binary.
 # Upgrade this to the k8s version of our clusters
-ENVTEST_K8S_VERSION = 1.20
+ENVTEST_K8S_VERSION = 1.21
 
 # Get the currently used golang install path (in GOPATH/bin, unless GOBIN is set)
 ifeq (,$(shell go env GOBIN))

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -204,6 +204,8 @@ var (
 	nameGenerator namegenerator.Generator
 	timeout       time.Duration = 45 * time.Second
 	poll          time.Duration = 5 * time.Second
+	ctx           context.Context
+	cancel        context.CancelFunc
 )
 
 func TestAPIs(t *testing.T) {
@@ -252,9 +254,11 @@ var _ = BeforeSuite(func() {
 	k8sClient = mgr.GetClient()
 	Expect(k8sClient).ToNot(BeNil())
 
+	ctx, cancel = context.WithCancel(context.Background())
+
 	go func() {
 		defer GinkgoRecover()
-		err = mgr.Start(ctrl.SetupSignalHandler())
+		err = mgr.Start(ctx)
 		Expect(err).ToNot(HaveOccurred())
 	}()
 
@@ -324,7 +328,9 @@ var _ = BeforeSuite(func() {
 }, 60)
 
 var _ = AfterSuite(func() {
+	cancel()
 	By("tearing down the test environment")
-	err := testEnv.Stop()
-	Expect(err).NotTo(HaveOccurred())
+	Eventually(func() error {
+		return testEnv.Stop()
+	}, timeout, poll).ShouldNot(HaveOccurred())
 })

--- a/pkg/reconcilers/workloads/test/suite_test.go
+++ b/pkg/reconcilers/workloads/test/suite_test.go
@@ -17,6 +17,7 @@ limitations under the License.
 package test
 
 import (
+	"context"
 	"path/filepath"
 	"testing"
 	"time"
@@ -46,6 +47,8 @@ var (
 	nameGenerator namegenerator.Generator
 	timeout       time.Duration = 30 * time.Second
 	poll          time.Duration = 5 * time.Second
+	ctx           context.Context
+	cancel        context.CancelFunc
 )
 
 func TestAPIs(t *testing.T) {
@@ -66,7 +69,6 @@ var _ = BeforeSuite(func() {
 			filepath.Join("..", "..", "..", "..", "config", "test", "external-apis"),
 		},
 	}
-
 	seed := time.Now().UTC().UnixNano()
 	nameGenerator = namegenerator.NewNameGenerator(seed)
 
@@ -92,9 +94,11 @@ var _ = BeforeSuite(func() {
 	k8sClient = mgr.GetClient()
 	Expect(k8sClient).ToNot(BeNil())
 
+	ctx, cancel = context.WithCancel(context.Background())
+
 	go func() {
 		defer GinkgoRecover()
-		err = mgr.Start(ctrl.SetupSignalHandler())
+		err = mgr.Start(ctx)
 		Expect(err).ToNot(HaveOccurred())
 	}()
 
@@ -108,7 +112,9 @@ var _ = BeforeSuite(func() {
 }, 60)
 
 var _ = AfterSuite(func() {
+	cancel()
 	By("tearing down the test environment")
-	err := testEnv.Stop()
-	Expect(err).NotTo(HaveOccurred())
+	Eventually(func() error {
+		return testEnv.Stop()
+	}, timeout, poll).ShouldNot(HaveOccurred())
 })


### PR DESCRIPTION
`pro-saas` and `stg-saas` are running k8s 1.21, so the `saas-operator` test environment should be updated accordingly.

v1.21 enables the `GracefullShutdown` feature for the API service and that requires some changes to the teardown step as described in https://github.com/kubernetes-sigs/controller-runtime/issues/1571#issuecomment-945535598 and https://github.com/kubernetes-sigs/controller-runtime/issues/1571.

/kind maintenance
/kind feature
/priority important-soon
/assign