### PR TITLE
Delete stale metrics

### DIFF
--- a/examples/backend/redis.yaml
+++ b/examples/backend/redis.yaml
@@ -12,7 +12,6 @@ metadata:
 spec: {}
 
 ---
----
 apiVersion: saas.3scale.net/v1alpha1
 kind: RedisShard
 metadata:


### PR DESCRIPTION
When a redis failover occurs, some vectors labelled with an old
combination of redis_server/redis_role keep reportingo old values and
never get updated or deleted.

This PR solves this problem by deleting any stale metrics each time
metrics are gathered from sentinel.

Closes #199 

/kind bug
/priority important-soon
/assign