### PR TITLE
fix/#198

### DIFF
--- a/controllers/sentinel_controller.go
+++ b/controllers/sentinel_controller.go
@@ -137,6 +137,7 @@ func (r *SentinelReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 			Instance:      instance,
 			SentinelURI:   uri,
 			ExportMetrics: true,
+			Topology:      &shardedCluster,
 		})
 		metricsGatherers = append(metricsGatherers, &metrics.SentinelMetricsGatherer{
 			RefreshInterval: *gen.Spec.Config.MetricsRefreshInterval,

--- a/pkg/redis/events/watcher.go
+++ b/pkg/redis/events/watcher.go
@@ -36,7 +36,7 @@ var (
 			Namespace: "saas_redis_sentinel",
 			Help:      "+sdown (https://redis.io/topics/sentinel#sentinel-api)",
 		},
-		[]string{"sentinel", "shard", "redis_server", "role"},
+		[]string{"sentinel", "shard", "redis_server"},
 	)
 	sdownSentinelCount = prometheus.NewCounterVec(
 		prometheus.CounterOpts{
@@ -44,7 +44,7 @@ var (
 			Namespace: "saas_redis_sentinel",
 			Help:      "+sdown (https://redis.io/topics/sentinel#sentinel-api)",
 		},
-		[]string{"sentinel", "shard", "redis_server", "role"},
+		[]string{"sentinel", "shard", "redis_server"},
 	)
 )
 

--- a/pkg/redis/events/watcher.go
+++ b/pkg/redis/events/watcher.go
@@ -2,6 +2,7 @@ package events
 
 import (
 	"context"
+	"fmt"
 
 	"github.com/3scale/saas-operator/pkg/reconcilers/threads"
 	"github.com/3scale/saas-operator/pkg/redis"

--- a/pkg/redis/events/watcher.go
+++ b/pkg/redis/events/watcher.go
@@ -147,22 +147,22 @@ func (sew *SentinelEventWatcher) Start(parentCtx context.Context, l logr.Logger)
 }
 
 // Stop stops the sentinel event watcher
-func (fw *SentinelEventWatcher) Stop() {
-	fw.cancel()
+func (sew *SentinelEventWatcher) Stop() {
+	sew.cancel()
 }
 
-func (smg *SentinelEventWatcher) metricsFromEvent(rem RedisEventMessage) {
+func (sew *SentinelEventWatcher) metricsFromEvent(rem RedisEventMessage) {
 	switch rem.event {
 	case "+switch-master":
 		switchMasterCount.With(
 			prometheus.Labels{
-				"sentinel": smg.SentinelURI, "shard": rem.target.name,
+				"sentinel": sew.SentinelURI, "shard": rem.target.name,
 			},
 		).Add(1)
 	case "-failover-abort-no-good-slave":
 		failoverAbortNoGoodSlaveCount.With(
 			prometheus.Labels{
-				"sentinel": smg.SentinelURI, "shard": rem.target.name,
+				"sentinel": sew.SentinelURI, "shard": rem.target.name,
 			},
 		).Add(1)
 	case "+sdown":


### PR DESCRIPTION
This PR fixes the sentinel counter metrics that were not initialized until an event occurred. These metrics are now initialized for all servers with 0 value.

```bash
❯ curl -s localhost:8080/metrics | grep sdown | grep shard01
saas_redis_sentinel_sdown_count{redis_server="redis-shard-shard01-0.redis-shard-shard01:6379",sentinel="redis://redis-sentinel-0.default.svc.cluster.local:26379",shard="shard01"} 0
saas_redis_sentinel_sdown_count{redis_server="redis-shard-shard01-0.redis-shard-shard01:6379",sentinel="redis://redis-sentinel-1.default.svc.cluster.local:26379",shard="shard01"} 0
saas_redis_sentinel_sdown_count{redis_server="redis-shard-shard01-0.redis-shard-shard01:6379",sentinel="redis://redis-sentinel-2.default.svc.cluster.local:26379",shard="shard01"} 0
saas_redis_sentinel_sdown_count{redis_server="redis-shard-shard01-1.redis-shard-shard01:6379",sentinel="redis://redis-sentinel-0.default.svc.cluster.local:26379",shard="shard01"} 0
saas_redis_sentinel_sdown_count{redis_server="redis-shard-shard01-1.redis-shard-shard01:6379",sentinel="redis://redis-sentinel-1.default.svc.cluster.local:26379",shard="shard01"} 0
saas_redis_sentinel_sdown_count{redis_server="redis-shard-shard01-1.redis-shard-shard01:6379",sentinel="redis://redis-sentinel-2.default.svc.cluster.local:26379",shard="shard01"} 0
saas_redis_sentinel_sdown_count{redis_server="redis-shard-shard01-2.redis-shard-shard01:6379",sentinel="redis://redis-sentinel-0.default.svc.cluster.local:26379",shard="shard01"} 0
saas_redis_sentinel_sdown_count{redis_server="redis-shard-shard01-2.redis-shard-shard01:6379",sentinel="redis://redis-sentinel-1.default.svc.cluster.local:26379",shard="shard01"} 0
saas_redis_sentinel_sdown_count{redis_server="redis-shard-shard01-2.redis-shard-shard01:6379",sentinel="redis://redis-sentinel-2.default.svc.cluster.local:26379",shard="shard01"} 0
saas_redis_sentinel_sdown_sentinel_count{redis_server="redis-shard-shard01-0.redis-shard-shard01:6379",sentinel="redis://redis-sentinel-0.default.svc.cluster.local:26379",shard="shard01"} 0
saas_redis_sentinel_sdown_sentinel_count{redis_server="redis-shard-shard01-0.redis-shard-shard01:6379",sentinel="redis://redis-sentinel-1.default.svc.cluster.local:26379",shard="shard01"} 0
saas_redis_sentinel_sdown_sentinel_count{redis_server="redis-shard-shard01-0.redis-shard-shard01:6379",sentinel="redis://redis-sentinel-2.default.svc.cluster.local:26379",shard="shard01"} 0
saas_redis_sentinel_sdown_sentinel_count{redis_server="redis-shard-shard01-1.redis-shard-shard01:6379",sentinel="redis://redis-sentinel-0.default.svc.cluster.local:26379",shard="shard01"} 0
saas_redis_sentinel_sdown_sentinel_count{redis_server="redis-shard-shard01-1.redis-shard-shard01:6379",sentinel="redis://redis-sentinel-1.default.svc.cluster.local:26379",shard="shard01"} 0
saas_redis_sentinel_sdown_sentinel_count{redis_server="redis-shard-shard01-1.redis-shard-shard01:6379",sentinel="redis://redis-sentinel-2.default.svc.cluster.local:26379",shard="shard01"} 0
saas_redis_sentinel_sdown_sentinel_count{redis_server="redis-shard-shard01-2.redis-shard-shard01:6379",sentinel="redis://redis-sentinel-0.default.svc.cluster.local:26379",shard="shard01"} 0
saas_redis_sentinel_sdown_sentinel_count{redis_server="redis-shard-shard01-2.redis-shard-shard01:6379",sentinel="redis://redis-sentinel-1.default.svc.cluster.local:26379",shard="shard01"} 0
saas_redis_sentinel_sdown_sentinel_count{redis_server="redis-shard-shard01-2.redis-shard-shard01:6379",sentinel="redis://redis-sentinel-2.default.svc.cluster.local:26379",shard="shard01"} 0
```

The PR also adds a new "server_info" metric with shard/server/role information because the role label has been removed from the "sdown" metrics to avoid weird behaviours when the role of a given server changes.

```bash
❯ curl -s localhost:8080/metrics | grep server_info
# HELP saas_redis_sentinel_server_info "redis server info"
# TYPE saas_redis_sentinel_server_info gauge
saas_redis_sentinel_server_info{redis_server="10.244.0.10:6379",role="slave",sentinel="redis://redis-sentinel-0.default.svc.cluster.local:26379",shard="shard02"} 1
saas_redis_sentinel_server_info{redis_server="10.244.0.10:6379",role="slave",sentinel="redis://redis-sentinel-1.default.svc.cluster.local:26379",shard="shard02"} 1
saas_redis_sentinel_server_info{redis_server="10.244.0.10:6379",role="slave",sentinel="redis://redis-sentinel-2.default.svc.cluster.local:26379",shard="shard02"} 1
saas_redis_sentinel_server_info{redis_server="10.244.0.11:6379",role="master",sentinel="redis://redis-sentinel-0.default.svc.cluster.local:26379",shard="shard02"} 1
saas_redis_sentinel_server_info{redis_server="10.244.0.11:6379",role="master",sentinel="redis://redis-sentinel-1.default.svc.cluster.local:26379",shard="shard02"} 1
saas_redis_sentinel_server_info{redis_server="10.244.0.11:6379",role="master",sentinel="redis://redis-sentinel-2.default.svc.cluster.local:26379",shard="shard02"} 1
saas_redis_sentinel_server_info{redis_server="10.244.0.21:6379",role="slave",sentinel="redis://redis-sentinel-0.default.svc.cluster.local:26379",shard="shard01"} 1
saas_redis_sentinel_server_info{redis_server="10.244.0.21:6379",role="slave",sentinel="redis://redis-sentinel-1.default.svc.cluster.local:26379",shard="shard01"} 1
saas_redis_sentinel_server_info{redis_server="10.244.0.21:6379",role="slave",sentinel="redis://redis-sentinel-2.default.svc.cluster.local:26379",shard="shard01"} 1
saas_redis_sentinel_server_info{redis_server="10.244.0.6:6379",role="slave",sentinel="redis://redis-sentinel-0.default.svc.cluster.local:26379",shard="shard01"} 1
saas_redis_sentinel_server_info{redis_server="10.244.0.6:6379",role="slave",sentinel="redis://redis-sentinel-1.default.svc.cluster.local:26379",shard="shard01"} 1
saas_redis_sentinel_server_info{redis_server="10.244.0.6:6379",role="slave",sentinel="redis://redis-sentinel-2.default.svc.cluster.local:26379",shard="shard01"} 1
saas_redis_sentinel_server_info{redis_server="10.244.0.7:6379",role="master",sentinel="redis://redis-sentinel-0.default.svc.cluster.local:26379",shard="shard01"} 1
saas_redis_sentinel_server_info{redis_server="10.244.0.7:6379",role="master",sentinel="redis://redis-sentinel-1.default.svc.cluster.local:26379",shard="shard01"} 1
saas_redis_sentinel_server_info{redis_server="10.244.0.7:6379",role="master",sentinel="redis://redis-sentinel-2.default.svc.cluster.local:26379",shard="shard01"} 1
saas_redis_sentinel_server_info{redis_server="10.244.0.8:6379",role="slave",sentinel="redis://redis-sentinel-0.default.svc.cluster.local:26379",shard="shard01"} 1
saas_redis_sentinel_server_info{redis_server="10.244.0.8:6379",role="slave",sentinel="redis://redis-sentinel-1.default.svc.cluster.local:26379",shard="shard01"} 1
saas_redis_sentinel_server_info{redis_server="10.244.0.8:6379",role="slave",sentinel="redis://redis-sentinel-2.default.svc.cluster.local:26379",shard="shard01"} 1
saas_redis_sentinel_server_info{redis_server="10.244.0.9:6379",role="slave",sentinel="redis://redis-sentinel-0.default.svc.cluster.local:26379",shard="shard02"} 1
saas_redis_sentinel_server_info{redis_server="10.244.0.9:6379",role="slave",sentinel="redis://redis-sentinel-1.default.svc.cluster.local:26379",shard="shard02"} 1
saas_redis_sentinel_server_info{redis_server="10.244.0.9:6379",role="slave",sentinel="redis://redis-sentinel-2.default.svc.cluster.local:26379",shard="shard02"} 1
```

Closes #198 

/kind bug
/priority important-soon
/assign
