### PR TITLE
fix: Update deprecated autoscaling api

### DIFF
--- a/controllers/apicast_controller.go
+++ b/controllers/apicast_controller.go
@@ -26,7 +26,7 @@ import (
 	"github.com/go-logr/logr"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	appsv1 "k8s.io/api/apps/v1"
-	autoscalingv2beta2 "k8s.io/api/autoscaling/v2beta2"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -101,7 +101,7 @@ func (r *ApicastReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&appsv1.Deployment{}).
 		Owns(&corev1.Service{}).
 		Owns(&policyv1.PodDisruptionBudget{}).
-		Owns(&autoscalingv2beta2.HorizontalPodAutoscaler{}).
+		Owns(&autoscalingv2.HorizontalPodAutoscaler{}).
 		Owns(&monitoringv1.PodMonitor{}).
 		Owns(&grafanav1alpha1.GrafanaDashboard{}).
 		Complete(r)

--- a/controllers/autossl_controller.go
+++ b/controllers/autossl_controller.go
@@ -27,7 +27,7 @@ import (
 	"github.com/go-logr/logr"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	appsv1 "k8s.io/api/apps/v1"
-	autoscalingv2beta2 "k8s.io/api/autoscaling/v2beta2"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -104,7 +104,7 @@ func (r *AutoSSLReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&appsv1.Deployment{}).
 		Owns(&corev1.Service{}).
 		Owns(&policyv1.PodDisruptionBudget{}).
-		Owns(&autoscalingv2beta2.HorizontalPodAutoscaler{}).
+		Owns(&autoscalingv2.HorizontalPodAutoscaler{}).
 		Owns(&monitoringv1.PodMonitor{}).
 		Owns(&grafanav1alpha1.GrafanaDashboard{}).
 		Complete(r)

--- a/controllers/backend_controller.go
+++ b/controllers/backend_controller.go
@@ -27,7 +27,7 @@ import (
 	"github.com/go-logr/logr"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	appsv1 "k8s.io/api/apps/v1"
-	autoscalingv2beta2 "k8s.io/api/autoscaling/v2beta2"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -117,7 +117,7 @@ func (r *BackendReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&appsv1.Deployment{}).
 		Owns(&corev1.Service{}).
 		Owns(&policyv1.PodDisruptionBudget{}).
-		Owns(&autoscalingv2beta2.HorizontalPodAutoscaler{}).
+		Owns(&autoscalingv2.HorizontalPodAutoscaler{}).
 		Owns(&monitoringv1.PodMonitor{}).
 		Owns(&externalsecretsv1beta1.ExternalSecret{}).
 		Owns(&grafanav1alpha1.GrafanaDashboard{}).

--- a/controllers/backend_controller_suite_test.go
+++ b/controllers/backend_controller_suite_test.go
@@ -13,7 +13,7 @@ import (
 	. "github.com/onsi/gomega"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	appsv1 "k8s.io/api/apps/v1"
-	autoscalingv2beta2 "k8s.io/api/autoscaling/v2beta2"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -254,7 +254,7 @@ var _ = Describe("Backend controller", func() {
 					rvs["deployment/backend-listener"] = testutil.GetResourceVersion(
 						k8sClient, &appsv1.Deployment{}, "backend-listener", namespace, timeout, poll)
 					rvs["hpa/backend-worker"] = testutil.GetResourceVersion(
-						k8sClient, &autoscalingv2beta2.HorizontalPodAutoscaler{}, "backend-worker", namespace, timeout, poll)
+						k8sClient, &autoscalingv2.HorizontalPodAutoscaler{}, "backend-worker", namespace, timeout, poll)
 					rvs["deployment/backend-cron"] = testutil.GetResourceVersion(
 						k8sClient, &appsv1.Deployment{}, "backend-cron", namespace, timeout, poll)
 					rvs["externalsecret/backend-internal-api"] = testutil.GetResourceVersion(
@@ -330,7 +330,7 @@ var _ = Describe("Backend controller", func() {
 				Expect(svc.Spec.Selector["deployment"]).To(Equal("backend-listener"))
 				Expect(svc.GetAnnotations()["service.beta.kubernetes.io/aws-load-balancer-cross-zone-load-balancing-enabled"]).To(Equal("false"))
 
-				hpa := &autoscalingv2beta2.HorizontalPodAutoscaler{}
+				hpa := &autoscalingv2.HorizontalPodAutoscaler{}
 				By("updating the backend-worker workload",
 					(&testutil.ExpectedResource{
 						Name:        "backend-worker",

--- a/controllers/corsproxy_controller.go
+++ b/controllers/corsproxy_controller.go
@@ -28,7 +28,7 @@ import (
 	"github.com/go-logr/logr"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	appsv1 "k8s.io/api/apps/v1"
-	autoscalingv2beta2 "k8s.io/api/autoscaling/v2beta2"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -105,7 +105,7 @@ func (r *CORSProxyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&appsv1.Deployment{}).
 		Owns(&corev1.Service{}).
 		Owns(&policyv1.PodDisruptionBudget{}).
-		Owns(&autoscalingv2beta2.HorizontalPodAutoscaler{}).
+		Owns(&autoscalingv2.HorizontalPodAutoscaler{}).
 		Owns(&monitoringv1.PodMonitor{}).
 		Owns(&externalsecretsv1beta1.ExternalSecret{}).
 		Owns(&grafanav1alpha1.GrafanaDashboard{}).

--- a/controllers/echoapi_controller.go
+++ b/controllers/echoapi_controller.go
@@ -26,7 +26,7 @@ import (
 	"github.com/go-logr/logr"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	appsv1 "k8s.io/api/apps/v1"
-	autoscalingv2beta2 "k8s.io/api/autoscaling/v2beta2"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -92,7 +92,7 @@ func (r *EchoAPIReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&appsv1.Deployment{}).
 		Owns(&corev1.Service{}).
 		Owns(&policyv1.PodDisruptionBudget{}).
-		Owns(&autoscalingv2beta2.HorizontalPodAutoscaler{}).
+		Owns(&autoscalingv2.HorizontalPodAutoscaler{}).
 		Owns(&monitoringv1.PodMonitor{}).
 		Owns(&grafanav1alpha1.GrafanaDashboard{}).
 		Complete(r)

--- a/controllers/mappingservice_controller.go
+++ b/controllers/mappingservice_controller.go
@@ -28,7 +28,7 @@ import (
 	"github.com/go-logr/logr"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	appsv1 "k8s.io/api/apps/v1"
-	autoscalingv2beta2 "k8s.io/api/autoscaling/v2beta2"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -105,7 +105,7 @@ func (r *MappingServiceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&appsv1.Deployment{}).
 		Owns(&corev1.Service{}).
 		Owns(&policyv1.PodDisruptionBudget{}).
-		Owns(&autoscalingv2beta2.HorizontalPodAutoscaler{}).
+		Owns(&autoscalingv2.HorizontalPodAutoscaler{}).
 		Owns(&monitoringv1.PodMonitor{}).
 		Owns(&externalsecretsv1beta1.ExternalSecret{}).
 		Owns(&grafanav1alpha1.GrafanaDashboard{}).

--- a/controllers/system_controller.go
+++ b/controllers/system_controller.go
@@ -27,7 +27,7 @@ import (
 	"github.com/go-logr/logr"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	appsv1 "k8s.io/api/apps/v1"
-	autoscalingv2beta2 "k8s.io/api/autoscaling/v2beta2"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -134,7 +134,7 @@ func (r *SystemReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&appsv1.StatefulSet{}).
 		Owns(&corev1.Service{}).
 		Owns(&policyv1.PodDisruptionBudget{}).
-		Owns(&autoscalingv2beta2.HorizontalPodAutoscaler{}).
+		Owns(&autoscalingv2.HorizontalPodAutoscaler{}).
 		Owns(&monitoringv1.PodMonitor{}).
 		Owns(&externalsecretsv1beta1.ExternalSecret{}).
 		Owns(&grafanav1alpha1.GrafanaDashboard{}).

--- a/controllers/system_controller_suite_test.go
+++ b/controllers/system_controller_suite_test.go
@@ -13,7 +13,7 @@ import (
 	. "github.com/onsi/gomega"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	appsv1 "k8s.io/api/apps/v1"
-	autoscalingv2beta2 "k8s.io/api/autoscaling/v2beta2"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -348,7 +348,7 @@ var _ = Describe("System controller", func() {
 					(&testutil.ExpectedResource{Name: "system-console", Namespace: namespace, Missing: true}).
 						Assert(k8sClient, pdb, timeout, poll))
 
-				hpa := &autoscalingv2beta2.HorizontalPodAutoscaler{}
+				hpa := &autoscalingv2.HorizontalPodAutoscaler{}
 				By("ensuring the system-console HPA",
 					(&testutil.ExpectedResource{Name: "system-console", Namespace: namespace, Missing: true}).
 						Assert(k8sClient, hpa, timeout, poll))

--- a/controllers/zync_controller.go
+++ b/controllers/zync_controller.go
@@ -27,7 +27,7 @@ import (
 	"github.com/go-logr/logr"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	appsv1 "k8s.io/api/apps/v1"
-	autoscalingv2beta2 "k8s.io/api/autoscaling/v2beta2"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -111,7 +111,7 @@ func (r *ZyncReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&appsv1.Deployment{}).
 		Owns(&corev1.Service{}).
 		Owns(&policyv1.PodDisruptionBudget{}).
-		Owns(&autoscalingv2beta2.HorizontalPodAutoscaler{}).
+		Owns(&autoscalingv2.HorizontalPodAutoscaler{}).
 		Owns(&monitoringv1.PodMonitor{}).
 		Owns(&externalsecretsv1beta1.ExternalSecret{}).
 		Owns(&grafanav1alpha1.GrafanaDashboard{}).

--- a/pkg/reconcilers/basereconciler/v2/reconciler.go
+++ b/pkg/reconcilers/basereconciler/v2/reconciler.go
@@ -14,7 +14,7 @@ import (
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	operatorutils "github.com/redhat-cop/operator-utils/pkg/util"
 	appsv1 "k8s.io/api/apps/v1"
-	autoscalingv2beta2 "k8s.io/api/autoscaling/v2beta2"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -36,7 +36,7 @@ var SupportedListTypes = []client.ObjectList{
 	&appsv1.StatefulSetList{},
 	&externalsecretsv1beta1.ExternalSecretList{},
 	&grafanav1alpha1.GrafanaDashboardList{},
-	&autoscalingv2beta2.HorizontalPodAutoscalerList{},
+	&autoscalingv2.HorizontalPodAutoscalerList{},
 	&policyv1.PodDisruptionBudgetList{},
 	&monitoringv1.PodMonitorList{},
 }

--- a/pkg/reconcilers/basereconciler/v2/resources/hpa.go
+++ b/pkg/reconcilers/basereconciler/v2/resources/hpa.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 
 	basereconciler "github.com/3scale/saas-operator/pkg/reconcilers/basereconciler/v2"
-	autoscalingv2beta2 "k8s.io/api/autoscaling/v2beta2"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
@@ -17,7 +17,7 @@ var _ basereconciler.Resource = HorizontalPodAutoscalerTemplate{}
 
 // HorizontalPodAutoscalerTemplate has methods to generate and reconcile a HorizontalPodAutoscaler
 type HorizontalPodAutoscalerTemplate struct {
-	Template  func() *autoscalingv2beta2.HorizontalPodAutoscaler
+	Template  func() *autoscalingv2.HorizontalPodAutoscaler
 	IsEnabled bool
 }
 
@@ -36,9 +36,9 @@ func (hpat HorizontalPodAutoscalerTemplate) ResourceReconciler(ctx context.Conte
 	logger := log.FromContext(ctx, "kind", "HorizontalPodAutoscaler", "resource", obj.GetName())
 
 	needsUpdate := false
-	desired := obj.(*autoscalingv2beta2.HorizontalPodAutoscaler)
+	desired := obj.(*autoscalingv2.HorizontalPodAutoscaler)
 
-	instance := &autoscalingv2beta2.HorizontalPodAutoscaler{}
+	instance := &autoscalingv2.HorizontalPodAutoscaler{}
 	err := cl.Get(ctx, types.NamespacedName{Name: desired.GetName(), Namespace: desired.GetNamespace()}, instance)
 	if err != nil {
 		if errors.IsNotFound(err) {

--- a/pkg/reconcilers/basereconciler/v2/test/test_controller.go
+++ b/pkg/reconcilers/basereconciler/v2/test/test_controller.go
@@ -30,7 +30,7 @@ import (
 	"github.com/3scale/saas-operator/pkg/resource_builders/pdb"
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
-	autoscalingv2beta2 "k8s.io/api/autoscaling/v2beta2"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -133,7 +133,7 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&appsv1.Deployment{}).
 		Owns(&corev1.Service{}).
 		Owns(&policyv1.PodDisruptionBudget{}).
-		Owns(&autoscalingv2beta2.HorizontalPodAutoscaler{}).
+		Owns(&autoscalingv2.HorizontalPodAutoscaler{}).
 		Owns(&externalsecretsv1beta1.ExternalSecret{}).
 		Watches(&source.Kind{Type: &corev1.Secret{TypeMeta: metav1.TypeMeta{Kind: "Secret"}}},
 			r.SecretEventHandler(&v1alpha1.TestList{}, r.Log)).

--- a/pkg/reconcilers/basereconciler/v2/test/test_controller_suite_test.go
+++ b/pkg/reconcilers/basereconciler/v2/test/test_controller_suite_test.go
@@ -10,7 +10,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
-	autoscalingv2beta2 "k8s.io/api/autoscaling/v2beta2"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -166,7 +166,7 @@ var _ = Describe("Test controller", func() {
 					pdb,
 				)
 			}, timeout, poll).ShouldNot(HaveOccurred())
-			hpa := &autoscalingv2beta2.HorizontalPodAutoscaler{}
+			hpa := &autoscalingv2.HorizontalPodAutoscaler{}
 			Eventually(func() error {
 				return k8sClient.Get(
 					context.Background(),

--- a/pkg/reconcilers/workloads/resources.go
+++ b/pkg/reconcilers/workloads/resources.go
@@ -9,7 +9,7 @@ import (
 	"github.com/3scale/saas-operator/pkg/util"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	appsv1 "k8s.io/api/apps/v1"
-	autoscalingv2beta2 "k8s.io/api/autoscaling/v2beta2"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -169,11 +169,11 @@ type HorizontalPodAutoscalerTemplate struct {
 
 func (hpat HorizontalPodAutoscalerTemplate) ApplyMeta(w WithWorkloadMeta) HorizontalPodAutoscalerTemplate {
 	fn := hpat.Template
-	hpat.Template = func() *autoscalingv2beta2.HorizontalPodAutoscaler {
+	hpat.Template = func() *autoscalingv2.HorizontalPodAutoscaler {
 		hpa := fn()
 		applyKey(hpa, w)
 		applyLabels(hpa, w)
-		hpa.Spec.ScaleTargetRef = autoscalingv2beta2.CrossVersionObjectReference{
+		hpa.Spec.ScaleTargetRef = autoscalingv2.CrossVersionObjectReference{
 			Kind:       "Deployment",
 			Name:       w.GetKey().Name,
 			APIVersion: appsv1.SchemeGroupVersion.String(),

--- a/pkg/reconcilers/workloads/resources_test.go
+++ b/pkg/reconcilers/workloads/resources_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/go-test/deep"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	appsv1 "k8s.io/api/apps/v1"
-	autoscalingv2beta2 "k8s.io/api/autoscaling/v2beta2"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -544,14 +544,14 @@ func TestHorizontalPodAutoscalerTemplate_ApplyMeta(t *testing.T) {
 		name string
 		hpat HorizontalPodAutoscalerTemplate
 		args args
-		want *autoscalingv2beta2.HorizontalPodAutoscaler
+		want *autoscalingv2.HorizontalPodAutoscaler
 	}{
 		{
 			name: "Adds meta to HPA",
 			hpat: HorizontalPodAutoscalerTemplate{
 				HorizontalPodAutoscalerTemplate: basereconciler_resources.HorizontalPodAutoscalerTemplate{
-					Template: func() *autoscalingv2beta2.HorizontalPodAutoscaler {
-						return &autoscalingv2beta2.HorizontalPodAutoscaler{}
+					Template: func() *autoscalingv2.HorizontalPodAutoscaler {
+						return &autoscalingv2.HorizontalPodAutoscaler{}
 					},
 					IsEnabled: false,
 				},
@@ -565,14 +565,14 @@ func TestHorizontalPodAutoscalerTemplate_ApplyMeta(t *testing.T) {
 					TSelector:  nil,
 				},
 			},
-			want: &autoscalingv2beta2.HorizontalPodAutoscaler{
+			want: &autoscalingv2.HorizontalPodAutoscaler{
 				ObjectMeta: metav1.ObjectMeta{
 					Name:      "test",
 					Namespace: "ns",
 					Labels:    map[string]string{"key": "value"},
 				},
-				Spec: autoscalingv2beta2.HorizontalPodAutoscalerSpec{
-					ScaleTargetRef: autoscalingv2beta2.CrossVersionObjectReference{
+				Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+					ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
 						Kind:       "Deployment",
 						Name:       "test",
 						APIVersion: "apps/v1",

--- a/pkg/reconcilers/workloads/test/test_controller.go
+++ b/pkg/reconcilers/workloads/test/test_controller.go
@@ -28,7 +28,7 @@ import (
 	"github.com/go-logr/logr"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	appsv1 "k8s.io/api/apps/v1"
-	autoscalingv2beta2 "k8s.io/api/autoscaling/v2beta2"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -100,7 +100,7 @@ func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Owns(&appsv1.Deployment{}).
 		Owns(&corev1.Service{}).
 		Owns(&policyv1.PodDisruptionBudget{}).
-		Owns(&autoscalingv2beta2.HorizontalPodAutoscaler{}).
+		Owns(&autoscalingv2.HorizontalPodAutoscaler{}).
 		Owns(&externalsecretsv1beta1.ExternalSecret{}).
 		Watches(&source.Kind{Type: &corev1.Secret{TypeMeta: metav1.TypeMeta{Kind: "Secret"}}},
 			r.SecretEventHandler(&v1alpha1.TestList{}, r.Log)).

--- a/pkg/reconcilers/workloads/test/test_controller_suite_test.go
+++ b/pkg/reconcilers/workloads/test/test_controller_suite_test.go
@@ -9,7 +9,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	appsv1 "k8s.io/api/apps/v1"
-	autoscalingv2beta2 "k8s.io/api/autoscaling/v2beta2"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -87,7 +87,7 @@ var _ = Describe("Test controller", func() {
 				Expect(alice.Spec.Template.GetLabels()).
 					To(Equal(map[string]string{"alice-lkey1": "alice-lvalue1", "deployment": "alice", "traffic": "yes", "orig-key": "orig-value"}))
 
-				hpa := &autoscalingv2beta2.HorizontalPodAutoscaler{}
+				hpa := &autoscalingv2.HorizontalPodAutoscaler{}
 				Eventually(func() error {
 					return k8sClient.Get(
 						context.Background(),
@@ -123,7 +123,7 @@ var _ = Describe("Test controller", func() {
 				Expect(bob.Spec.Template.GetLabels()).
 					To(Equal(map[string]string{"bob-lkey1": "bob-lvalue1", "deployment": "bob", "traffic": "yes", "orig-key": "orig-value"}))
 
-				hpa := &autoscalingv2beta2.HorizontalPodAutoscaler{}
+				hpa := &autoscalingv2.HorizontalPodAutoscaler{}
 				Eventually(func() error {
 					return k8sClient.Get(
 						context.Background(),

--- a/pkg/resource_builders/hpa/resource.go
+++ b/pkg/resource_builders/hpa/resource.go
@@ -3,7 +3,7 @@ package hpa
 import (
 	saasv1alpha1 "github.com/3scale/saas-operator/api/v1alpha1"
 	appsv1 "k8s.io/api/apps/v1"
-	autoscalingv2beta2 "k8s.io/api/autoscaling/v2beta2"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -11,29 +11,29 @@ import (
 
 // New returns a basereconciler_types.GeneratorFunction function that will return an HorizontalPodAutoscaler
 // resource when called
-func New(key types.NamespacedName, labels map[string]string, cfg saasv1alpha1.HorizontalPodAutoscalerSpec) func() *autoscalingv2beta2.HorizontalPodAutoscaler {
+func New(key types.NamespacedName, labels map[string]string, cfg saasv1alpha1.HorizontalPodAutoscalerSpec) func() *autoscalingv2.HorizontalPodAutoscaler {
 
-	return func() *autoscalingv2beta2.HorizontalPodAutoscaler {
-		hpa := autoscalingv2beta2.HorizontalPodAutoscaler{
+	return func() *autoscalingv2.HorizontalPodAutoscaler {
+		hpa := autoscalingv2.HorizontalPodAutoscaler{
 			TypeMeta: metav1.TypeMeta{
 				Kind:       "HorizontalPodAutoscaler",
-				APIVersion: autoscalingv2beta2.SchemeGroupVersion.String(),
+				APIVersion: autoscalingv2.SchemeGroupVersion.String(),
 			},
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      key.Name,
 				Namespace: key.Namespace,
 				Labels:    labels,
 			},
-			Spec: autoscalingv2beta2.HorizontalPodAutoscalerSpec{
-				ScaleTargetRef: autoscalingv2beta2.CrossVersionObjectReference{
+			Spec: autoscalingv2.HorizontalPodAutoscalerSpec{
+				ScaleTargetRef: autoscalingv2.CrossVersionObjectReference{
 					APIVersion: appsv1.SchemeGroupVersion.String(),
 					Kind:       "Deployment",
 					Name:       key.Name,
 				},
 				MinReplicas: cfg.MinReplicas,
 			},
-			Status: autoscalingv2beta2.HorizontalPodAutoscalerStatus{
-				Conditions: []autoscalingv2beta2.HorizontalPodAutoscalerCondition{},
+			Status: autoscalingv2.HorizontalPodAutoscalerStatus{
+				Conditions: []autoscalingv2.HorizontalPodAutoscalerCondition{},
 			},
 		}
 
@@ -42,13 +42,13 @@ func New(key types.NamespacedName, labels map[string]string, cfg saasv1alpha1.Ho
 		}
 
 		if cfg.ResourceName != nil {
-			hpa.Spec.Metrics = []autoscalingv2beta2.MetricSpec{
+			hpa.Spec.Metrics = []autoscalingv2.MetricSpec{
 				{
-					Type: autoscalingv2beta2.ResourceMetricSourceType,
-					Resource: &autoscalingv2beta2.ResourceMetricSource{
+					Type: autoscalingv2.ResourceMetricSourceType,
+					Resource: &autoscalingv2.ResourceMetricSource{
 						Name: corev1.ResourceName(*cfg.ResourceName),
-						Target: autoscalingv2beta2.MetricTarget{
-							Type:               autoscalingv2beta2.UtilizationMetricType,
+						Target: autoscalingv2.MetricTarget{
+							Type:               autoscalingv2.UtilizationMetricType,
 							AverageUtilization: cfg.ResourceUtilization,
 						},
 					},

--- a/test/util/assert.go
+++ b/test/util/assert.go
@@ -9,7 +9,7 @@ import (
 	. "github.com/onsi/gomega"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
 	appsv1 "k8s.io/api/apps/v1"
-	autoscalingv2beta2 "k8s.io/api/autoscaling/v2beta2"
+	autoscalingv2 "k8s.io/api/autoscaling/v2"
 	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/pointer"
@@ -59,7 +59,7 @@ func (ew *ExpectedWorkload) Assert(c client.Client, dep *appsv1.Deployment, time
 			Expect(dep.Spec.Template.Spec.Containers[0].Args).To(Equal(ew.ContainterArgs))
 		}
 
-		hpa := &autoscalingv2beta2.HorizontalPodAutoscaler{}
+		hpa := &autoscalingv2.HorizontalPodAutoscaler{}
 		By(fmt.Sprintf("%s workload HPA", ew.Name),
 			(&ExpectedResource{
 				Name:      ew.Name,


### PR DESCRIPTION
- Updates the `autoscaling` to `v2`, as `autoscaling/v2beta2` HorizontalPodAutoscaler is deprecated in v1.23+, unavailable in v1.26+.

/kind feature
/priority important-longterm 
/assign