### PR TITLE
Drop usage of lockedresource reconciler from operator-utils

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 0.17.1-alpha.8
+VERSION ?= 0.17.1-alpha.9
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 0.17.1-alpha.9
+VERSION ?= 0.17.1-alpha.11
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/bundle/manifests/saas-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/saas-operator.clusterserviceversion.yaml
@@ -574,7 +574,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/3scale/saas-operator
     support: Red Hat
-  name: saas-operator.v0.17.1-alpha.9
+  name: saas-operator.v0.17.1-alpha.11
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -4393,7 +4393,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
-                image: quay.io/3scale/saas-operator:v0.17.1-alpha.9
+                image: quay.io/3scale/saas-operator:v0.17.1-alpha.11
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -4895,4 +4895,4 @@ spec:
   provider:
     name: Red Hat
     url: https://www.3scale.net/
-  version: 0.17.1-alpha.9
+  version: 0.17.1-alpha.11

--- a/bundle/manifests/saas-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/saas-operator.clusterserviceversion.yaml
@@ -574,7 +574,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/3scale/saas-operator
     support: Red Hat
-  name: saas-operator.v0.17.1-alpha.8
+  name: saas-operator.v0.17.1-alpha.9
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -4393,7 +4393,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
-                image: quay.io/3scale/saas-operator:v0.17.1-alpha.8
+                image: quay.io/3scale/saas-operator:v0.17.1-alpha.9
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -4895,4 +4895,4 @@ spec:
   provider:
     name: Red Hat
     url: https://www.3scale.net/
-  version: 0.17.1-alpha.8
+  version: 0.17.1-alpha.9

--- a/bundle/manifests/saas.3scale.net_apicasts.yaml
+++ b/bundle/manifests/saas.3scale.net_apicasts.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: apicasts.saas.3scale.net
 spec:

--- a/bundle/manifests/saas.3scale.net_autossls.yaml
+++ b/bundle/manifests/saas.3scale.net_autossls.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: autossls.saas.3scale.net
 spec:

--- a/bundle/manifests/saas.3scale.net_backends.yaml
+++ b/bundle/manifests/saas.3scale.net_backends.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: backends.saas.3scale.net
 spec:

--- a/bundle/manifests/saas.3scale.net_corsproxies.yaml
+++ b/bundle/manifests/saas.3scale.net_corsproxies.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: corsproxies.saas.3scale.net
 spec:

--- a/bundle/manifests/saas.3scale.net_echoapis.yaml
+++ b/bundle/manifests/saas.3scale.net_echoapis.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: echoapis.saas.3scale.net
 spec:

--- a/bundle/manifests/saas.3scale.net_mappingservices.yaml
+++ b/bundle/manifests/saas.3scale.net_mappingservices.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: mappingservices.saas.3scale.net
 spec:

--- a/bundle/manifests/saas.3scale.net_redisshards.yaml
+++ b/bundle/manifests/saas.3scale.net_redisshards.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: redisshards.saas.3scale.net
 spec:

--- a/bundle/manifests/saas.3scale.net_sentinels.yaml
+++ b/bundle/manifests/saas.3scale.net_sentinels.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: sentinels.saas.3scale.net
 spec:

--- a/bundle/manifests/saas.3scale.net_systems.yaml
+++ b/bundle/manifests/saas.3scale.net_systems.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: systems.saas.3scale.net
 spec:

--- a/bundle/manifests/saas.3scale.net_twemproxyconfigs.yaml
+++ b/bundle/manifests/saas.3scale.net_twemproxyconfigs.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: twemproxyconfigs.saas.3scale.net
 spec:

--- a/bundle/manifests/saas.3scale.net_zyncs.yaml
+++ b/bundle/manifests/saas.3scale.net_zyncs.yaml
@@ -2,7 +2,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: zyncs.saas.3scale.net
 spec:

--- a/config/crd/bases/saas.3scale.net_apicasts.yaml
+++ b/config/crd/bases/saas.3scale.net_apicasts.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: apicasts.saas.3scale.net
 spec:

--- a/config/crd/bases/saas.3scale.net_autossls.yaml
+++ b/config/crd/bases/saas.3scale.net_autossls.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: autossls.saas.3scale.net
 spec:

--- a/config/crd/bases/saas.3scale.net_backends.yaml
+++ b/config/crd/bases/saas.3scale.net_backends.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: backends.saas.3scale.net
 spec:

--- a/config/crd/bases/saas.3scale.net_corsproxies.yaml
+++ b/config/crd/bases/saas.3scale.net_corsproxies.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: corsproxies.saas.3scale.net
 spec:

--- a/config/crd/bases/saas.3scale.net_echoapis.yaml
+++ b/config/crd/bases/saas.3scale.net_echoapis.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: echoapis.saas.3scale.net
 spec:

--- a/config/crd/bases/saas.3scale.net_mappingservices.yaml
+++ b/config/crd/bases/saas.3scale.net_mappingservices.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: mappingservices.saas.3scale.net
 spec:

--- a/config/crd/bases/saas.3scale.net_redisshards.yaml
+++ b/config/crd/bases/saas.3scale.net_redisshards.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: redisshards.saas.3scale.net
 spec:

--- a/config/crd/bases/saas.3scale.net_sentinels.yaml
+++ b/config/crd/bases/saas.3scale.net_sentinels.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: sentinels.saas.3scale.net
 spec:

--- a/config/crd/bases/saas.3scale.net_systems.yaml
+++ b/config/crd/bases/saas.3scale.net_systems.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: systems.saas.3scale.net
 spec:

--- a/config/crd/bases/saas.3scale.net_twemproxyconfigs.yaml
+++ b/config/crd/bases/saas.3scale.net_twemproxyconfigs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: twemproxyconfigs.saas.3scale.net
 spec:

--- a/config/crd/bases/saas.3scale.net_zyncs.yaml
+++ b/config/crd/bases/saas.3scale.net_zyncs.yaml
@@ -3,7 +3,7 @@ apiVersion: apiextensions.k8s.io/v1
 kind: CustomResourceDefinition
 metadata:
   annotations:
-    controller-gen.kubebuilder.io/version: v0.9.2
+    controller-gen.kubebuilder.io/version: v0.10.0
   creationTimestamp: null
   name: zyncs.saas.3scale.net
 spec:

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,4 +13,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/3scale/saas-operator
-  newTag: v0.17.1-alpha.9
+  newTag: v0.17.1-alpha.11

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,4 +13,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/3scale/saas-operator
-  newTag: v0.17.1-alpha.8
+  newTag: v0.17.1-alpha.9

--- a/controllers/apicast_controller.go
+++ b/controllers/apicast_controller.go
@@ -59,7 +59,7 @@ func (r *ApicastReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 	instance := &saasv1alpha1.Apicast{}
 	key := types.NamespacedName{Name: req.Name, Namespace: req.Namespace}
-	result, err := r.GetInstance(ctx, key, instance, saasv1alpha1.Finalizer, nil)
+	result, err := r.GetInstance(ctx, key, instance, nil, nil)
 	if result != nil || err != nil {
 		return *result, err
 	}

--- a/controllers/autossl_controller.go
+++ b/controllers/autossl_controller.go
@@ -59,7 +59,7 @@ func (r *AutoSSLReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 	instance := &saasv1alpha1.AutoSSL{}
 	key := types.NamespacedName{Name: req.Name, Namespace: req.Namespace}
-	result, err := r.GetInstance(ctx, key, instance, saasv1alpha1.Finalizer, nil)
+	result, err := r.GetInstance(ctx, key, instance, nil, nil)
 	if result != nil || err != nil {
 		return *result, err
 	}

--- a/controllers/autossl_controller.go
+++ b/controllers/autossl_controller.go
@@ -26,16 +26,13 @@ import (
 	"github.com/3scale/saas-operator/pkg/reconcilers/workloads"
 	"github.com/go-logr/logr"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
-	"github.com/redhat-cop/operator-utils/pkg/util"
+	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv2beta2 "k8s.io/api/autoscaling/v2beta2"
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/builder"
-	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
 // AutoSSLReconciler reconciles a AutoSSL object
@@ -76,7 +73,7 @@ func (r *AutoSSLReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		instance.Spec,
 	)
 	if err != nil {
-		return r.ManageError(ctx, instance, err)
+		return ctrl.Result{}, err
 	}
 
 	// Shared resources
@@ -87,33 +84,33 @@ func (r *AutoSSLReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	// Workload resources
 	var workload []basereconciler.Resource
 	if instance.Spec.Canary != nil {
-		workload, err = r.NewDeploymentWorkloadWithTraffic(ctx, instance, r.GetScheme(), &gen, &gen, gen.Canary)
+		workload, err = r.NewDeploymentWorkloadWithTraffic(ctx, instance, &gen, &gen, gen.Canary)
 	} else {
-		workload, err = r.NewDeploymentWorkloadWithTraffic(ctx, instance, r.GetScheme(), &gen, &gen)
+		workload, err = r.NewDeploymentWorkloadWithTraffic(ctx, instance, &gen, &gen)
 	}
 	if err != nil {
-		return r.ManageError(ctx, instance, err)
+		return ctrl.Result{}, err
 	}
 	resources = append(resources, workload...)
 
 	err = r.ReconcileOwnedResources(ctx, instance, resources)
 	if err != nil {
 		logger.Error(err, "unable to update owned resources")
-		return r.ManageError(ctx, instance, err)
+		return ctrl.Result{}, err
 	}
 
-	return r.ManageSuccess(ctx, instance)
+	return ctrl.Result{}, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *AutoSSLReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&saasv1alpha1.AutoSSL{}, builder.WithPredicates(util.ResourceGenerationOrFinalizerChangedPredicate{})).
+		For(&saasv1alpha1.AutoSSL{}).
+		Owns(&appsv1.Deployment{}).
 		Owns(&corev1.Service{}).
 		Owns(&policyv1.PodDisruptionBudget{}).
 		Owns(&autoscalingv2beta2.HorizontalPodAutoscaler{}).
 		Owns(&monitoringv1.PodMonitor{}).
 		Owns(&grafanav1alpha1.GrafanaDashboard{}).
-		Watches(&source.Channel{Source: r.GetStatusChangeChannel()}, &handler.EnqueueRequestForObject{}).
 		Complete(r)
 }

--- a/controllers/backend_controller.go
+++ b/controllers/backend_controller.go
@@ -64,7 +64,7 @@ func (r *BackendReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 	instance := &saasv1alpha1.Backend{}
 	key := types.NamespacedName{Name: req.Name, Namespace: req.Namespace}
-	result, err := r.GetInstance(ctx, key, instance, saasv1alpha1.Finalizer, nil)
+	result, err := r.GetInstance(ctx, key, instance, nil, nil)
 	if result != nil || err != nil {
 		return *result, err
 	}

--- a/controllers/backend_controller.go
+++ b/controllers/backend_controller.go
@@ -27,15 +27,13 @@ import (
 	"github.com/3scale/saas-operator/pkg/reconcilers/workloads"
 	"github.com/go-logr/logr"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
-	"github.com/redhat-cop/operator-utils/pkg/util"
+	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv2beta2 "k8s.io/api/autoscaling/v2beta2"
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/builder"
-	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
@@ -76,7 +74,7 @@ func (r *BackendReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 	gen, err := backend.NewGenerator(instance.GetName(), instance.GetNamespace(), instance.Spec)
 	if err != nil {
-		return r.ManageError(ctx, instance, err)
+		return ctrl.Result{}, err
 	}
 
 	// Shared resources
@@ -85,31 +83,31 @@ func (r *BackendReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	// Listener resources
 	var listener_resources []basereconciler.Resource
 	if instance.Spec.Listener.Canary != nil {
-		listener_resources, err = r.NewDeploymentWorkloadWithTraffic(ctx, instance, r.GetScheme(), &gen.Listener, &gen.Listener, gen.CanaryListener)
+		listener_resources, err = r.NewDeploymentWorkloadWithTraffic(ctx, instance, &gen.Listener, &gen.Listener, gen.CanaryListener)
 	} else {
-		listener_resources, err = r.NewDeploymentWorkloadWithTraffic(ctx, instance, r.GetScheme(), &gen.Listener, &gen.Listener)
+		listener_resources, err = r.NewDeploymentWorkloadWithTraffic(ctx, instance, &gen.Listener, &gen.Listener)
 	}
 	if err != nil {
-		return r.ManageError(ctx, instance, err)
+		return ctrl.Result{}, err
 	}
 	resources = append(resources, listener_resources...)
 
 	// Worker resources
 	var worker_resources []basereconciler.Resource
 	if instance.Spec.Worker.Canary != nil {
-		worker_resources, err = r.NewDeploymentWorkload(ctx, instance, r.GetScheme(), &gen.Worker, gen.CanaryWorker)
+		worker_resources, err = r.NewDeploymentWorkload(ctx, instance, &gen.Worker, gen.CanaryWorker)
 	} else {
-		worker_resources, err = r.NewDeploymentWorkload(ctx, instance, r.GetScheme(), &gen.Worker)
+		worker_resources, err = r.NewDeploymentWorkload(ctx, instance, &gen.Worker)
 	}
 	if err != nil {
-		return r.ManageError(ctx, instance, err)
+		return ctrl.Result{}, err
 	}
 	resources = append(resources, worker_resources...)
 
 	// Cron resources
-	cron_resources, err := r.NewDeploymentWorkload(ctx, instance, r.GetScheme(), &gen.Cron)
+	cron_resources, err := r.NewDeploymentWorkload(ctx, instance, &gen.Cron)
 	if err != nil {
-		return r.ManageError(ctx, instance, err)
+		return ctrl.Result{}, err
 	}
 	resources = append(resources, cron_resources...)
 
@@ -117,7 +115,7 @@ func (r *BackendReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 	err = r.ReconcileOwnedResources(ctx, instance, resources)
 	if err != nil {
 		logger.Error(err, "unable to reconcile owned resources")
-		return r.ManageError(ctx, instance, err)
+		return ctrl.Result{}, err
 	}
 
 	return ctrl.Result{}, nil
@@ -126,14 +124,14 @@ func (r *BackendReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 // SetupWithManager sets up the controller with the Manager.
 func (r *BackendReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&saasv1alpha1.Backend{}, builder.WithPredicates(util.ResourceGenerationOrFinalizerChangedPredicate{})).
+		For(&saasv1alpha1.Backend{}).
+		Owns(&appsv1.Deployment{}).
 		Owns(&corev1.Service{}).
 		Owns(&policyv1.PodDisruptionBudget{}).
 		Owns(&autoscalingv2beta2.HorizontalPodAutoscaler{}).
 		Owns(&monitoringv1.PodMonitor{}).
 		Owns(&externalsecretsv1beta1.ExternalSecret{}).
 		Owns(&grafanav1alpha1.GrafanaDashboard{}).
-		Watches(&source.Channel{Source: r.GetStatusChangeChannel()}, &handler.EnqueueRequestForObject{}).
 		Watches(&source.Kind{Type: &corev1.Secret{TypeMeta: metav1.TypeMeta{Kind: "Secret"}}},
 			r.SecretEventHandler(&saasv1alpha1.BackendList{}, r.Log)).
 		Complete(r)

--- a/controllers/backend_controller_suite_test.go
+++ b/controllers/backend_controller_suite_test.go
@@ -101,11 +101,6 @@ var _ = Describe("Backend controller", func() {
 				return k8sClient.Get(context.Background(), types.NamespacedName{Name: "instance", Namespace: namespace}, backend)
 			}, timeout, poll).ShouldNot(HaveOccurred())
 
-			Eventually(func() bool {
-				err := k8sClient.Get(context.Background(), types.NamespacedName{Name: "instance", Namespace: namespace}, backend)
-				Expect(err).ToNot(HaveOccurred())
-				return len(backend.GetFinalizers()) > 0
-			}, timeout, poll).Should(BeTrue())
 		})
 
 		It("creates the required backend workload resources", func() {

--- a/controllers/corsproxy_controller.go
+++ b/controllers/corsproxy_controller.go
@@ -64,7 +64,7 @@ func (r *CORSProxyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 
 	instance := &saasv1alpha1.CORSProxy{}
 	key := types.NamespacedName{Name: req.Name, Namespace: req.Namespace}
-	result, err := r.GetInstance(ctx, key, instance, saasv1alpha1.Finalizer, nil)
+	result, err := r.GetInstance(ctx, key, instance, nil, nil)
 	if result != nil || err != nil {
 		return *result, err
 	}

--- a/controllers/corsproxy_controller.go
+++ b/controllers/corsproxy_controller.go
@@ -27,13 +27,13 @@ import (
 	"github.com/3scale/saas-operator/pkg/reconcilers/workloads"
 	"github.com/go-logr/logr"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv2beta2 "k8s.io/api/autoscaling/v2beta2"
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
@@ -84,32 +84,32 @@ func (r *CORSProxyReconciler) Reconcile(ctx context.Context, req ctrl.Request) (
 	}
 
 	var workload []basereconciler.Resource
-	workload, err = r.NewDeploymentWorkloadWithTraffic(ctx, instance, r.GetScheme(), &gen, &gen)
+	workload, err = r.NewDeploymentWorkloadWithTraffic(ctx, instance, &gen, &gen)
 	if err != nil {
-		return r.ManageError(ctx, instance, err)
+		return ctrl.Result{}, err
 	}
 	resources = append(resources, workload...)
 
 	err = r.ReconcileOwnedResources(ctx, instance, resources)
 	if err != nil {
 		logger.Error(err, "unable to reconcile owned resources")
-		return r.ManageError(ctx, instance, err)
+		return ctrl.Result{}, err
 	}
 
-	return r.ManageSuccess(ctx, instance)
+	return ctrl.Result{}, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *CORSProxyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&saasv1alpha1.CORSProxy{}).
+		Owns(&appsv1.Deployment{}).
 		Owns(&corev1.Service{}).
 		Owns(&policyv1.PodDisruptionBudget{}).
 		Owns(&autoscalingv2beta2.HorizontalPodAutoscaler{}).
 		Owns(&monitoringv1.PodMonitor{}).
 		Owns(&externalsecretsv1beta1.ExternalSecret{}).
 		Owns(&grafanav1alpha1.GrafanaDashboard{}).
-		Watches(&source.Channel{Source: r.GetStatusChangeChannel()}, &handler.EnqueueRequestForObject{}).
 		Watches(&source.Kind{Type: &corev1.Secret{TypeMeta: metav1.TypeMeta{Kind: "Secret"}}},
 			r.SecretEventHandler(&saasv1alpha1.CORSProxyList{}, r.Log)).
 		Complete(r)

--- a/controllers/echoapi_controller.go
+++ b/controllers/echoapi_controller.go
@@ -57,7 +57,7 @@ func (r *EchoAPIReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 
 	instance := &saasv1alpha1.EchoAPI{}
 	key := types.NamespacedName{Name: req.Name, Namespace: req.Namespace}
-	result, err := r.GetInstance(ctx, key, instance, saasv1alpha1.Finalizer, nil)
+	result, err := r.GetInstance(ctx, key, instance, nil, nil)
 	if result != nil || err != nil {
 		return *result, err
 	}

--- a/controllers/echoapi_controller.go
+++ b/controllers/echoapi_controller.go
@@ -25,16 +25,13 @@ import (
 	"github.com/3scale/saas-operator/pkg/reconcilers/workloads"
 	"github.com/go-logr/logr"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
-	"github.com/redhat-cop/operator-utils/pkg/util"
+	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv2beta2 "k8s.io/api/autoscaling/v2beta2"
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/builder"
-	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
 // EchoAPIReconciler reconciles a EchoAPI object
@@ -74,29 +71,29 @@ func (r *EchoAPIReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ct
 		instance.Spec,
 	)
 
-	resources, err := r.NewDeploymentWorkloadWithTraffic(ctx, instance, r.GetScheme(), &gen, &gen)
+	resources, err := r.NewDeploymentWorkloadWithTraffic(ctx, instance, &gen, &gen)
 	if err != nil {
-		return r.ManageError(ctx, instance, err)
+		return ctrl.Result{}, err
 	}
 
 	err = r.ReconcileOwnedResources(ctx, instance, resources)
 	if err != nil {
 		logger.Error(err, "unable to update owned resources")
-		return r.ManageError(ctx, instance, err)
+		return ctrl.Result{}, err
 	}
 
-	return r.ManageSuccess(ctx, instance)
+	return ctrl.Result{}, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *EchoAPIReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&saasv1alpha1.EchoAPI{}, builder.WithPredicates(util.ResourceGenerationOrFinalizerChangedPredicate{})).
+		For(&saasv1alpha1.EchoAPI{}).
+		Owns(&appsv1.Deployment{}).
 		Owns(&corev1.Service{}).
 		Owns(&policyv1.PodDisruptionBudget{}).
 		Owns(&autoscalingv2beta2.HorizontalPodAutoscaler{}).
 		Owns(&monitoringv1.PodMonitor{}).
 		Owns(&grafanav1alpha1.GrafanaDashboard{}).
-		Watches(&source.Channel{Source: r.GetStatusChangeChannel()}, &handler.EnqueueRequestForObject{}).
 		Complete(r)
 }

--- a/controllers/mappingservice_controller.go
+++ b/controllers/mappingservice_controller.go
@@ -64,7 +64,7 @@ func (r *MappingServiceReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 
 	instance := &saasv1alpha1.MappingService{}
 	key := types.NamespacedName{Name: req.Name, Namespace: req.Namespace}
-	result, err := r.GetInstance(ctx, key, instance, saasv1alpha1.Finalizer, nil)
+	result, err := r.GetInstance(ctx, key, instance, nil, nil)
 	if result != nil || err != nil {
 		return *result, err
 	}

--- a/controllers/mappingservice_controller.go
+++ b/controllers/mappingservice_controller.go
@@ -27,15 +27,13 @@ import (
 	"github.com/3scale/saas-operator/pkg/reconcilers/workloads"
 	"github.com/go-logr/logr"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
-	"github.com/redhat-cop/operator-utils/pkg/util"
+	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv2beta2 "k8s.io/api/autoscaling/v2beta2"
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/builder"
-	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
@@ -86,32 +84,32 @@ func (r *MappingServiceReconciler) Reconcile(ctx context.Context, req ctrl.Reque
 	}
 
 	var workload []basereconciler.Resource
-	workload, err = r.NewDeploymentWorkloadWithTraffic(ctx, instance, r.GetScheme(), &gen, &gen)
+	workload, err = r.NewDeploymentWorkloadWithTraffic(ctx, instance, &gen, &gen)
 	if err != nil {
-		return r.ManageError(ctx, instance, err)
+		return ctrl.Result{}, err
 	}
 	resources = append(resources, workload...)
 
 	err = r.ReconcileOwnedResources(ctx, instance, resources)
 	if err != nil {
 		logger.Error(err, "unable to reconcile owned resources")
-		return r.ManageError(ctx, instance, err)
+		return ctrl.Result{}, err
 	}
 
-	return r.ManageSuccess(ctx, instance)
+	return ctrl.Result{}, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *MappingServiceReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&saasv1alpha1.MappingService{}, builder.WithPredicates(util.ResourceGenerationOrFinalizerChangedPredicate{})).
+		For(&saasv1alpha1.MappingService{}).
+		Owns(&appsv1.Deployment{}).
 		Owns(&corev1.Service{}).
 		Owns(&policyv1.PodDisruptionBudget{}).
 		Owns(&autoscalingv2beta2.HorizontalPodAutoscaler{}).
 		Owns(&monitoringv1.PodMonitor{}).
 		Owns(&externalsecretsv1beta1.ExternalSecret{}).
 		Owns(&grafanav1alpha1.GrafanaDashboard{}).
-		Watches(&source.Channel{Source: r.GetStatusChangeChannel()}, &handler.EnqueueRequestForObject{}).
 		Watches(&source.Kind{Type: &corev1.Secret{TypeMeta: metav1.TypeMeta{Kind: "Secret"}}},
 			r.SecretEventHandler(&saasv1alpha1.MappingServiceList{}, r.Log)).
 		Complete(r)

--- a/controllers/redisshard_controller.go
+++ b/controllers/redisshard_controller.go
@@ -57,7 +57,7 @@ func (r *RedisShardReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 	instance := &saasv1alpha1.RedisShard{}
 	key := types.NamespacedName{Name: req.Name, Namespace: req.Namespace}
-	result, err := r.GetInstance(ctx, key, instance, saasv1alpha1.Finalizer, nil)
+	result, err := r.GetInstance(ctx, key, instance, nil, nil)
 	if result != nil || err != nil {
 		return *result, err
 	}

--- a/controllers/redisshard_controller.go
+++ b/controllers/redisshard_controller.go
@@ -27,14 +27,13 @@ import (
 	"github.com/3scale/saas-operator/pkg/redis"
 	"github.com/3scale/saas-operator/pkg/redis/crud/client"
 	"github.com/go-logr/logr"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/utils/pointer"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
-	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
 // RedisShardReconciler reconciles a RedisShard object
@@ -74,7 +73,7 @@ func (r *RedisShardReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 
 	if err := r.ReconcileOwnedResources(ctx, instance, gen.Resources()); err != nil {
 		logger.Error(err, "unable to update owned resources")
-		return r.ManageError(ctx, instance, err)
+		return ctrl.Result{}, err
 	}
 
 	shard, result, err := r.setRedisRoles(ctx, types.NamespacedName{Name: req.Name, Namespace: req.Namespace},
@@ -98,9 +97,9 @@ func (r *RedisShardReconciler) Reconcile(ctx context.Context, req ctrl.Request) 
 func (r *RedisShardReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&saasv1alpha1.RedisShard{}).
+		Owns(&appsv1.StatefulSet{}).
 		Owns(&corev1.Service{}).
 		Owns(&corev1.ConfigMap{}).
-		Watches(&source.Channel{Source: r.GetStatusChangeChannel()}, &handler.EnqueueRequestForObject{}).
 		Complete(r)
 }
 
@@ -110,7 +109,7 @@ func (r *RedisShardReconciler) setRedisRoles(ctx context.Context, key types.Name
 	for i := 0; i < int(replicas); i++ {
 		pod := &corev1.Pod{}
 		key := types.NamespacedName{Name: fmt.Sprintf("%s-%d", serviceName, i), Namespace: key.Namespace}
-		err := r.GetClient().Get(ctx, key, pod)
+		err := r.Client.Get(ctx, key, pod)
 		if err != nil {
 			return &redis.Shard{Name: key.Name}, &ctrl.Result{}, err
 		}
@@ -147,7 +146,7 @@ func (r *RedisShardReconciler) updateStatus(ctx context.Context, shard *redis.Sh
 	}
 	if !equality.Semantic.DeepEqual(status, instance.Status) {
 		instance.Status = status
-		if err := r.GetClient().Status().Update(ctx, instance); err != nil {
+		if err := r.Client.Status().Update(ctx, instance); err != nil {
 			return err
 		}
 	}

--- a/controllers/sentinel_controller.go
+++ b/controllers/sentinel_controller.go
@@ -35,6 +35,7 @@ import (
 	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/pointer"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
@@ -69,7 +70,7 @@ func (r *SentinelReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	result, err := r.GetInstance(ctx,
 		key,
 		instance,
-		saasv1alpha1.Finalizer,
+		pointer.String(saasv1alpha1.Finalizer),
 		[]func(){r.SentinelEvents.CleanupThreads(instance), r.Metrics.CleanupThreads(instance)})
 	if result != nil || err != nil {
 		return *result, err

--- a/controllers/sentinel_controller.go
+++ b/controllers/sentinel_controller.go
@@ -30,6 +30,7 @@ import (
 	"github.com/3scale/saas-operator/pkg/redis/events"
 	"github.com/3scale/saas-operator/pkg/redis/metrics"
 	"github.com/go-logr/logr"
+	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	"k8s.io/apimachinery/pkg/api/equality"
@@ -85,18 +86,18 @@ func (r *SentinelReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 
 	if err := r.ReconcileOwnedResources(ctx, instance, gen.Resources()); err != nil {
 		logger.Error(err, "unable to update owned resources")
-		return r.ManageError(ctx, instance, err)
+		return ctrl.Result{}, err
 	}
 
 	// Create the redis-sentinel server pool
-	sentinelPool, err := redis.NewSentinelPool(ctx, r.GetClient(),
+	sentinelPool, err := redis.NewSentinelPool(ctx, r.Client,
 		types.NamespacedName{Name: gen.GetComponent(), Namespace: gen.GetNamespace()}, int(*instance.Spec.Replicas))
 
 	// Close Redis clients
 	defer sentinelPool.Cleanup(logger)
 
 	if err != nil {
-		return r.ManageError(ctx, instance, err)
+		return ctrl.Result{}, err
 	}
 
 	// Create the ShardedCluster objects that represents the redis servers to be monitored by sentinel
@@ -106,20 +107,20 @@ func (r *SentinelReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 	defer shardedCluster.Cleanup(logger)
 
 	if err != nil {
-		return r.ManageError(ctx, instance, err)
+		return ctrl.Result{}, err
 	}
 
 	// Ensure all shards are being monitored
 	allMonitored, err := sentinelPool.IsMonitoringShards(ctx, shardedCluster.GetShardNames())
 	if err != nil {
-		return r.ManageError(ctx, instance, err)
+		return ctrl.Result{}, err
 	}
 	if !allMonitored {
 		if err := shardedCluster.Discover(ctx, logger); err != nil {
-			return r.ManageError(ctx, instance, err)
+			return ctrl.Result{}, err
 		}
 		if _, err := sentinelPool.Monitor(ctx, shardedCluster); err != nil {
-			return r.ManageError(ctx, instance, err)
+			return ctrl.Result{}, err
 		}
 	}
 
@@ -139,15 +140,15 @@ func (r *SentinelReconciler) Reconcile(ctx context.Context, req ctrl.Request) (c
 		})
 	}
 	if err := r.SentinelEvents.ReconcileThreads(ctx, instance, eventWatchers, logger.WithName("event-watcher")); err != nil {
-		return r.ManageError(ctx, instance, err)
+		return ctrl.Result{}, err
 	}
 	if err := r.Metrics.ReconcileThreads(ctx, instance, metricsGatherers, logger.WithName("metrics-gatherer")); err != nil {
-		return r.ManageError(ctx, instance, err)
+		return ctrl.Result{}, err
 	}
 
 	// Reconcile status of the Sentinel resource
 	if err := r.reconcileStatus(ctx, instance, &gen, sentinelPool, logger); err != nil {
-		return r.ManageError(ctx, instance, err)
+		return ctrl.Result{}, err
 	}
 
 	return ctrl.Result{RequeueAfter: 30 * time.Second}, nil
@@ -167,7 +168,7 @@ func (r *SentinelReconciler) reconcileStatus(ctx context.Context, instance *saas
 	for i := 0; i < replicas; i++ {
 		key := types.NamespacedName{Name: gen.PodServiceName(i), Namespace: instance.GetNamespace()}
 		svc := &corev1.Service{}
-		if err := r.GetClient().Get(ctx, key, svc); err != nil {
+		if err := r.Client.Get(ctx, key, svc); err != nil {
 			return err
 		}
 		addressList = append(addressList, fmt.Sprintf("%s:%d", svc.Spec.ClusterIP, saasv1alpha1.SentinelPort))
@@ -180,7 +181,7 @@ func (r *SentinelReconciler) reconcileStatus(ctx context.Context, instance *saas
 
 	if !equality.Semantic.DeepEqual(status, instance.Status) {
 		instance.Status = status
-		if err := r.GetClient().Status().Update(ctx, instance); err != nil {
+		if err := r.Client.Status().Update(ctx, instance); err != nil {
 			return err
 		}
 	}
@@ -192,11 +193,11 @@ func (r *SentinelReconciler) reconcileStatus(ctx context.Context, instance *saas
 func (r *SentinelReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&saasv1alpha1.Sentinel{}).
+		Owns(&appsv1.StatefulSet{}).
 		Owns(&corev1.Service{}).
 		Owns(&policyv1.PodDisruptionBudget{}).
 		Owns(&grafanav1alpha1.GrafanaDashboard{}).
 		Owns(&corev1.ConfigMap{}).
-		Watches(&source.Channel{Source: r.GetStatusChangeChannel()}, &handler.EnqueueRequestForObject{}).
 		Watches(&source.Channel{Source: r.SentinelEvents.GetChannel()}, &handler.EnqueueRequestForObject{}).
 		Complete(r)
 }

--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -145,13 +145,13 @@ var _ = BeforeSuite(func() {
 	Expect(err).ToNot(HaveOccurred())
 
 	err = (&RedisShardReconciler{
-		Reconciler: basereconciler.NewFromManager(mgr, "RedisShard", false),
+		Reconciler: basereconciler.NewFromManager(mgr),
 		Log:        ctrl.Log.WithName("controllers").WithName("RedisShard"),
 	}).SetupWithManager(mgr)
 	Expect(err).ToNot(HaveOccurred())
 
 	err = (&SentinelReconciler{
-		Reconciler:     basereconciler.NewFromManager(mgr, "Sentinel", false),
+		Reconciler:     basereconciler.NewFromManager(mgr),
 		SentinelEvents: threads.NewManager(),
 		Metrics:        threads.NewManager(),
 		Log:            ctrl.Log.WithName("controllers").WithName("Sentinel"),

--- a/controllers/system_controller.go
+++ b/controllers/system_controller.go
@@ -64,7 +64,7 @@ func (r *SystemReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctr
 
 	instance := &saasv1alpha1.System{}
 	key := types.NamespacedName{Name: req.Name, Namespace: req.Namespace}
-	result, err := r.GetInstance(ctx, key, instance, saasv1alpha1.Finalizer, nil)
+	result, err := r.GetInstance(ctx, key, instance, nil, nil)
 	if result != nil || err != nil {
 		return *result, err
 	}

--- a/controllers/system_controller_suite_test.go
+++ b/controllers/system_controller_suite_test.go
@@ -126,12 +126,6 @@ var _ = Describe("System controller", func() {
 				return k8sClient.Get(context.Background(), types.NamespacedName{Name: "instance", Namespace: namespace}, system)
 			}, timeout, poll).ShouldNot(HaveOccurred())
 
-			Eventually(func() bool {
-				err := k8sClient.Get(context.Background(), types.NamespacedName{Name: "instance", Namespace: namespace}, system)
-				Expect(err).ToNot(HaveOccurred())
-				return len(system.GetFinalizers()) > 0
-			}, timeout, poll).Should(BeTrue())
-
 		})
 
 		It("creates the required system-app resources", func() {

--- a/controllers/twemproxyconfig_controller.go
+++ b/controllers/twemproxyconfig_controller.go
@@ -34,6 +34,7 @@ import (
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/utils/pointer"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
@@ -62,7 +63,8 @@ func (r *TwemproxyConfigReconciler) Reconcile(ctx context.Context, req ctrl.Requ
 
 	instance := &saasv1alpha1.TwemproxyConfig{}
 	key := types.NamespacedName{Name: req.Name, Namespace: req.Namespace}
-	result, err := r.GetInstance(ctx, key, instance, saasv1alpha1.Finalizer,
+	result, err := r.GetInstance(ctx, key, instance,
+		pointer.String(saasv1alpha1.Finalizer),
 		[]func(){r.SentinelEvents.CleanupThreads(instance)})
 	if result != nil || err != nil {
 		return *result, err

--- a/controllers/zync_controller.go
+++ b/controllers/zync_controller.go
@@ -63,7 +63,7 @@ func (r *ZyncReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 
 	instance := &saasv1alpha1.Zync{}
 	key := types.NamespacedName{Name: req.Name, Namespace: req.Namespace}
-	result, err := r.GetInstance(ctx, key, instance, saasv1alpha1.Finalizer, nil)
+	result, err := r.GetInstance(ctx, key, instance, nil, nil)
 	if result != nil || err != nil {
 		return *result, err
 	}

--- a/controllers/zync_controller.go
+++ b/controllers/zync_controller.go
@@ -26,15 +26,13 @@ import (
 	"github.com/3scale/saas-operator/pkg/reconcilers/workloads"
 	"github.com/go-logr/logr"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
-	"github.com/redhat-cop/operator-utils/pkg/util"
+	appsv1 "k8s.io/api/apps/v1"
 	autoscalingv2beta2 "k8s.io/api/autoscaling/v2beta2"
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/builder"
-	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
@@ -83,16 +81,16 @@ func (r *ZyncReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 	resources := gen.Resources()
 
 	// Api resources
-	api_resources, err := r.NewDeploymentWorkloadWithTraffic(ctx, instance, r.GetScheme(), &gen.API, &gen.API)
+	api_resources, err := r.NewDeploymentWorkloadWithTraffic(ctx, instance, &gen.API, &gen.API)
 	if err != nil {
-		return r.ManageError(ctx, instance, err)
+		return ctrl.Result{}, err
 	}
 	resources = append(resources, api_resources...)
 
 	// Que resources
-	que_resources, err := r.NewDeploymentWorkload(ctx, instance, r.GetScheme(), &gen.Que)
+	que_resources, err := r.NewDeploymentWorkload(ctx, instance, &gen.Que)
 	if err != nil {
-		return r.ManageError(ctx, instance, err)
+		return ctrl.Result{}, err
 	}
 	resources = append(resources, que_resources...)
 
@@ -100,7 +98,7 @@ func (r *ZyncReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 	err = r.ReconcileOwnedResources(ctx, instance, resources)
 	if err != nil {
 		logger.Error(err, "unable to reconcile owned resources")
-		return r.ManageError(ctx, instance, err)
+		return ctrl.Result{}, err
 	}
 
 	return ctrl.Result{}, nil
@@ -109,14 +107,14 @@ func (r *ZyncReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.
 // SetupWithManager sets up the controller with the Manager.
 func (r *ZyncReconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
-		For(&saasv1alpha1.Zync{}, builder.WithPredicates(util.ResourceGenerationOrFinalizerChangedPredicate{})).
+		For(&saasv1alpha1.Zync{}).
+		Owns(&appsv1.Deployment{}).
 		Owns(&corev1.Service{}).
 		Owns(&policyv1.PodDisruptionBudget{}).
 		Owns(&autoscalingv2beta2.HorizontalPodAutoscaler{}).
 		Owns(&monitoringv1.PodMonitor{}).
 		Owns(&externalsecretsv1beta1.ExternalSecret{}).
 		Owns(&grafanav1alpha1.GrafanaDashboard{}).
-		Watches(&source.Channel{Source: r.GetStatusChangeChannel()}, &handler.EnqueueRequestForObject{}).
 		Watches(&source.Kind{Type: &corev1.Secret{TypeMeta: metav1.TypeMeta{Kind: "Secret"}}},
 			r.SecretEventHandler(&saasv1alpha1.ZyncList{}, r.Log)).
 		Complete(r)

--- a/go.mod
+++ b/go.mod
@@ -60,8 +60,6 @@ require (
 	github.com/google/gnostic v0.5.7-v3refs // indirect
 	github.com/google/gofuzz v1.1.0 // indirect
 	github.com/google/uuid v1.1.2 // indirect
-	github.com/hashicorp/errwrap v1.0.0 // indirect
-	github.com/hashicorp/go-multierror v1.1.1 // indirect
 	github.com/huandu/xstrings v1.3.1 // indirect
 	github.com/imdario/mergo v0.3.12 // indirect
 	github.com/josharian/intern v1.0.0 // indirect
@@ -74,12 +72,10 @@ require (
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect
 	github.com/modern-go/reflect2 v1.0.2 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
-	github.com/nsf/jsondiff v0.0.0-20210926074059-1e845ec5d249 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/prometheus/client_model v0.2.0 // indirect
 	github.com/prometheus/common v0.32.1 // indirect
 	github.com/prometheus/procfs v0.7.3 // indirect
-	github.com/scylladb/go-set v1.0.2 // indirect
 	github.com/shopspring/decimal v1.2.0 // indirect
 	github.com/spf13/cast v1.3.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -163,8 +163,6 @@ github.com/evanphx/json-patch/v5 v5.6.0/go.mod h1:G79N1coSVB93tBe7j6PhzjmR3/2Vvl
 github.com/exponent-io/jsonpath v0.0.0-20151013193312-d6023ce2651d/go.mod h1:ZZMPRZwes7CROmyNKgQzC3XPs6L/G2EJLHddWejkmf4=
 github.com/fatih/camelcase v1.0.0/go.mod h1:yN2Sb0lFhZJUdVvtELVWefmrXpuZESvPmqwoZc+/fpc=
 github.com/fatih/color v1.7.0/go.mod h1:Zm6kSWBoL9eyXnKyktHP6abPY2pDugNf5KwzbycvMj4=
-github.com/fatih/set v0.2.1 h1:nn2CaJyknWE/6txyUDGwysr3G5QC6xWB/PtVjPBbeaA=
-github.com/fatih/set v0.2.1/go.mod h1:+RKtMCH+favT2+3YecHGxcc0b4KyVWA1QWWJUs4E0CI=
 github.com/felixge/httpsnoop v1.0.1/go.mod h1:m8KPJKqk1gH5J9DgRY2ASl2lWCfGKXixSwevea8zH2U=
 github.com/form3tech-oss/jwt-go v3.2.2+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
 github.com/form3tech-oss/jwt-go v3.2.3+incompatible/go.mod h1:pbq4aXjuKjdthFRnoDwaVPLA+WlJuPGy+QneDUgJi2k=
@@ -318,14 +316,11 @@ github.com/gregjones/httpcache v0.0.0-20180305231024-9cad4c3443a7/go.mod h1:Fecb
 github.com/grpc-ecosystem/grpc-gateway v1.16.0/go.mod h1:BDjrQk3hbvj6Nolgz8mAMFbcEtjT1g+wF4CSlocrBnw=
 github.com/hashicorp/consul/api v1.1.0/go.mod h1:VmuI/Lkw1nC05EYQWNKwWGbkg+FbDBtguAZLlVdkD9Q=
 github.com/hashicorp/consul/sdk v0.1.1/go.mod h1:VKf9jXwCTEY1QZP2MOLRhb5i/I/ssyNV1vwHyQBF0x8=
-github.com/hashicorp/errwrap v1.0.0 h1:hLrqtEDnRye3+sgx6z4qVLNuviH3MR5aQ0ykNJa/UYA=
 github.com/hashicorp/errwrap v1.0.0/go.mod h1:YH+1FKiLXxHSkmPseP+kNlulaMuP3n2brvKWEqk/Jc4=
 github.com/hashicorp/go-cleanhttp v0.5.1/go.mod h1:JpRdi6/HCYpAwUzNwuwqhbovhLtngrth3wmdIIUrZ80=
 github.com/hashicorp/go-immutable-radix v1.0.0/go.mod h1:0y9vanUI8NX6FsYoO3zeMjhV/C5i9g4Q3DwcSNZ4P60=
 github.com/hashicorp/go-msgpack v0.5.3/go.mod h1:ahLV/dePpqEmjfWmKiqvPkv/twdG7iPBM1vqhUKIvfM=
 github.com/hashicorp/go-multierror v1.0.0/go.mod h1:dHtQlpGsu+cZNNAkkCN/P3hoUDHhCYQXV3UM06sGGrk=
-github.com/hashicorp/go-multierror v1.1.1 h1:H5DkEtf6CXdFp0N0Em5UCwQpXMWke8IA0+lD48awMYo=
-github.com/hashicorp/go-multierror v1.1.1/go.mod h1:iw975J/qwKPdAO1clOe2L8331t/9/fmwbPZ6JB6eMoM=
 github.com/hashicorp/go-rootcerts v1.0.0/go.mod h1:K6zTfqpRlCUIjkwsN4Z+hiSfzSTQa6eBIzfwKfwNnHU=
 github.com/hashicorp/go-sockaddr v1.0.0/go.mod h1:7Xibr9yA9JjQq1JpNB2Vw7kxv8xerXegt+ozgdvDeDU=
 github.com/hashicorp/go-syslog v1.0.0/go.mod h1:qPfqrKkXGihmCqbJM2mZgkZGvKG1dFdvsLplgctolz4=
@@ -428,8 +423,6 @@ github.com/mwitkow/go-conntrack v0.0.0-20190716064945-2f068394615f/go.mod h1:qRW
 github.com/mxk/go-flowrate v0.0.0-20140419014527-cca7078d478f/go.mod h1:ZdcZmHo+o7JKHSa8/e818NopupXU1YMK5fe1lsApnBw=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
-github.com/nsf/jsondiff v0.0.0-20210926074059-1e845ec5d249 h1:NHrXEjTNQY7P0Zfx1aMrNhpgxHmow66XQtm0aQLY0AE=
-github.com/nsf/jsondiff v0.0.0-20210926074059-1e845ec5d249/go.mod h1:mpRZBD8SJ55OIICQ3iWH0Yz3cjzA61JdqMLoWXeB2+8=
 github.com/nxadm/tail v1.4.4/go.mod h1:kenIhsEOeOJmVchQTgglprH7qJGnHDVpk1VPCcaMI8A=
 github.com/nxadm/tail v1.4.8 h1:nPr65rt6Y5JFSKQO7qToXr7pePgD6Gwiw05lkbyAQTE=
 github.com/olekukonko/tablewriter v0.0.4/go.mod h1:zq6QwlOf5SlnkVbMSr5EoBv3636FWnp+qbPhuoO21uA=
@@ -496,8 +489,6 @@ github.com/russross/blackfriday v1.5.2/go.mod h1:JO/DiYxRf+HjHt06OyowR9PTA263kcR
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/russross/blackfriday/v2 v2.1.0/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
-github.com/scylladb/go-set v1.0.2 h1:SkvlMCKhP0wyyct6j+0IHJkBkSZL+TDzZ4E7f7BCcRE=
-github.com/scylladb/go-set v1.0.2/go.mod h1:DkpGd78rljTxKAnTDPFqXSGxvETQnJyuSOQwsHycqfs=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/shopspring/decimal v1.2.0 h1:abSATXmQEYyShuxI4/vyW3tV1MrKAJzCZ/0zLUXYbsQ=

--- a/main.go
+++ b/main.go
@@ -28,14 +28,6 @@ import (
 
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 
-	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
-	apimachineryruntime "k8s.io/apimachinery/pkg/runtime"
-	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
-	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
-	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/cache"
-	"sigs.k8s.io/controller-runtime/pkg/healthz"
-
 	saasv1alpha1 "github.com/3scale/saas-operator/api/v1alpha1"
 	"github.com/3scale/saas-operator/controllers"
 	externalsecretsv1beta1 "github.com/3scale/saas-operator/pkg/apis/externalsecrets/v1beta1"
@@ -45,6 +37,13 @@ import (
 	"github.com/3scale/saas-operator/pkg/reconcilers/workloads"
 	"github.com/3scale/saas-operator/pkg/util"
 	"github.com/3scale/saas-operator/pkg/version"
+	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	apimachineryruntime "k8s.io/apimachinery/pkg/runtime"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/healthz"
 	// +kubebuilder:scaffold:imports
 )
 
@@ -131,7 +130,7 @@ func main() {
 	/* BASERECONCILER_V2 BASED CONTROLLERS*/
 
 	if err = (&controllers.SentinelReconciler{
-		Reconciler:     basereconciler.NewFromManager(mgr, "Sentinel", clusterWatch),
+		Reconciler:     basereconciler.NewFromManager(mgr),
 		SentinelEvents: threads.NewManager(),
 		Metrics:        threads.NewManager(),
 		Log:            ctrl.Log.WithName("controllers").WithName("Sentinel"),
@@ -140,14 +139,14 @@ func main() {
 		os.Exit(1)
 	}
 	if err = (&controllers.RedisShardReconciler{
-		Reconciler: basereconciler.NewFromManager(mgr, "RedisShard", clusterWatch),
+		Reconciler: basereconciler.NewFromManager(mgr),
 		Log:        ctrl.Log.WithName("controllers").WithName("RedisShard"),
 	}).SetupWithManager(mgr); err != nil {
 		setupLog.Error(err, "unable to create controller", "controller", "RedisShard")
 		os.Exit(1)
 	}
 	if err = (&controllers.TwemproxyConfigReconciler{
-		Reconciler:     basereconciler.NewFromManager(mgr, "TwemproxyConfig", clusterWatch),
+		Reconciler:     basereconciler.NewFromManager(mgr),
 		SentinelEvents: threads.NewManager(),
 		Log:            ctrl.Log.WithName("controllers").WithName("TwemproxyConfig"),
 	}).SetupWithManager(mgr); err != nil {

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -101,7 +101,7 @@ func dashboardsApicastServicesJsonGtpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "dashboards/apicast-services.json.gtpl", size: 17460, mode: os.FileMode(436), modTime: time.Unix(1667483034, 0)}
+	info := bindataFileInfo{name: "dashboards/apicast-services.json.gtpl", size: 17460, mode: os.FileMode(420), modTime: time.Unix(1636028060, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -121,7 +121,7 @@ func dashboardsApicastJsonGtpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "dashboards/apicast.json.gtpl", size: 84552, mode: os.FileMode(436), modTime: time.Unix(1667483034, 0)}
+	info := bindataFileInfo{name: "dashboards/apicast.json.gtpl", size: 84552, mode: os.FileMode(420), modTime: time.Unix(1665072543, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -141,7 +141,7 @@ func dashboardsAutosslJsonGtpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "dashboards/autossl.json.gtpl", size: 59366, mode: os.FileMode(436), modTime: time.Unix(1667483034, 0)}
+	info := bindataFileInfo{name: "dashboards/autossl.json.gtpl", size: 59366, mode: os.FileMode(420), modTime: time.Unix(1665072543, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -161,7 +161,7 @@ func dashboardsBackendJsonGtpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "dashboards/backend.json.gtpl", size: 122812, mode: os.FileMode(436), modTime: time.Unix(1667483034, 0)}
+	info := bindataFileInfo{name: "dashboards/backend.json.gtpl", size: 122812, mode: os.FileMode(420), modTime: time.Unix(1665072543, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -181,7 +181,7 @@ func dashboardsCorsProxyJsonGtpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "dashboards/cors-proxy.json.gtpl", size: 78737, mode: os.FileMode(436), modTime: time.Unix(1667483034, 0)}
+	info := bindataFileInfo{name: "dashboards/cors-proxy.json.gtpl", size: 78737, mode: os.FileMode(420), modTime: time.Unix(1665072543, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -201,7 +201,7 @@ func dashboardsMappingServiceJsonGtpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "dashboards/mapping-service.json.gtpl", size: 70528, mode: os.FileMode(436), modTime: time.Unix(1667483034, 0)}
+	info := bindataFileInfo{name: "dashboards/mapping-service.json.gtpl", size: 70528, mode: os.FileMode(420), modTime: time.Unix(1665072543, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -221,7 +221,7 @@ func dashboardsRedisSentinelJsonGtpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "dashboards/redis-sentinel.json.gtpl", size: 131661, mode: os.FileMode(436), modTime: time.Unix(1667483034, 0)}
+	info := bindataFileInfo{name: "dashboards/redis-sentinel.json.gtpl", size: 131661, mode: os.FileMode(420), modTime: time.Unix(1665072543, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -241,7 +241,7 @@ func dashboardsSystemJsonGtpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "dashboards/system.json.gtpl", size: 81338, mode: os.FileMode(436), modTime: time.Unix(1667483034, 0)}
+	info := bindataFileInfo{name: "dashboards/system.json.gtpl", size: 81338, mode: os.FileMode(420), modTime: time.Unix(1665072543, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -261,7 +261,7 @@ func dashboardsTwemproxyJsonGtpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "dashboards/twemproxy.json.gtpl", size: 130875, mode: os.FileMode(436), modTime: time.Unix(1667483034, 0)}
+	info := bindataFileInfo{name: "dashboards/twemproxy.json.gtpl", size: 130875, mode: os.FileMode(420), modTime: time.Unix(1665072543, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -281,7 +281,7 @@ func dashboardsZyncJsonGtpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "dashboards/zync.json.gtpl", size: 70304, mode: os.FileMode(436), modTime: time.Unix(1667483034, 0)}
+	info := bindataFileInfo{name: "dashboards/zync.json.gtpl", size: 70304, mode: os.FileMode(420), modTime: time.Unix(1665072543, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/pkg/reconcilers/basereconciler/v2/resources/services.go
+++ b/pkg/reconcilers/basereconciler/v2/resources/services.go
@@ -14,7 +14,6 @@ import (
 )
 
 var _ basereconciler.Resource = ServiceTemplate{}
-var _ basereconciler.ResourceWithCustomReconciler = ServiceTemplate{}
 
 // ServiceTemplate has methods to generate and reconcile a Service
 type ServiceTemplate struct {

--- a/pkg/reconcilers/basereconciler/v2/test/suite_test.go
+++ b/pkg/reconcilers/basereconciler/v2/test/suite_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 	"time"
 
+	saasv1alpha1 "github.com/3scale/saas-operator/api/v1alpha1"
 	externalsecretsv1beta1 "github.com/3scale/saas-operator/pkg/apis/externalsecrets/v1beta1"
 	grafanav1alpha1 "github.com/3scale/saas-operator/pkg/apis/grafana/v1alpha1"
 	basereconciler "github.com/3scale/saas-operator/pkg/reconcilers/basereconciler/v2"
@@ -30,6 +31,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	"k8s.io/client-go/rest"
 	ctrl "sigs.k8s.io/controller-runtime"
@@ -77,14 +79,11 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	Expect(cfg).NotTo(BeNil())
 
-	err = v1alpha1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-	err = monitoringv1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-	err = grafanav1alpha1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-	err = externalsecretsv1beta1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
+	utilruntime.Must(v1alpha1.AddToScheme(scheme.Scheme))
+	utilruntime.Must(saasv1alpha1.AddToScheme(scheme.Scheme))
+	utilruntime.Must(monitoringv1.AddToScheme(scheme.Scheme))
+	utilruntime.Must(grafanav1alpha1.AddToScheme(scheme.Scheme))
+	utilruntime.Must(externalsecretsv1beta1.AddToScheme(scheme.Scheme))
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		Scheme: scheme.Scheme,
@@ -107,7 +106,7 @@ var _ = BeforeSuite(func() {
 
 	// Add controllers for testing
 	err = (&Reconciler{
-		Reconciler: basereconciler.NewFromManager(mgr, "Test", false),
+		Reconciler: basereconciler.NewFromManager(mgr),
 		Log:        ctrl.Log.WithName("controllers").WithName("Test"),
 	}).SetupWithManager(mgr)
 	Expect(err).ToNot(HaveOccurred())

--- a/pkg/reconcilers/basereconciler/v2/test/test_controller.go
+++ b/pkg/reconcilers/basereconciler/v2/test/test_controller.go
@@ -30,6 +30,7 @@ import (
 	"github.com/3scale/saas-operator/pkg/resource_builders/pdb"
 	"github.com/go-logr/logr"
 	appsv1 "k8s.io/api/apps/v1"
+	autoscalingv2beta2 "k8s.io/api/autoscaling/v2beta2"
 	corev1 "k8s.io/api/core/v1"
 	policyv1 "k8s.io/api/policy/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -37,7 +38,6 @@ import (
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/utils/pointer"
 	ctrl "sigs.k8s.io/controller-runtime"
-	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 	"sigs.k8s.io/controller-runtime/pkg/source"
 )
@@ -120,18 +120,21 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 	if err != nil {
 		logger.Error(err, "unable to reconcile owned resources")
-		return r.ManageError(ctx, instance, err)
+		return ctrl.Result{}, err
 	}
 
-	return r.ManageSuccess(ctx, instance)
+	return ctrl.Result{}, nil
 }
 
 // SetupWithManager sets up the controller with the Manager.
 func (r *Reconciler) SetupWithManager(mgr ctrl.Manager) error {
 	return ctrl.NewControllerManagedBy(mgr).
 		For(&v1alpha1.Test{}).
-		Owns(&corev1.Service{}).Owns(&policyv1.PodDisruptionBudget{}).
-		Watches(&source.Channel{Source: r.GetStatusChangeChannel()}, &handler.EnqueueRequestForObject{}).
+		Owns(&appsv1.Deployment{}).
+		Owns(&corev1.Service{}).
+		Owns(&policyv1.PodDisruptionBudget{}).
+		Owns(&autoscalingv2beta2.HorizontalPodAutoscaler{}).
+		Owns(&externalsecretsv1beta1.ExternalSecret{}).
 		Watches(&source.Kind{Type: &corev1.Secret{TypeMeta: metav1.TypeMeta{Kind: "Secret"}}},
 			r.SecretEventHandler(&v1alpha1.TestList{}, r.Log)).
 		Complete(r)

--- a/pkg/reconcilers/basereconciler/v2/test/test_controller.go
+++ b/pkg/reconcilers/basereconciler/v2/test/test_controller.go
@@ -57,7 +57,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 	instance := &v1alpha1.Test{}
 	key := types.NamespacedName{Name: req.Name, Namespace: req.Namespace}
-	result, err := r.GetInstance(ctx, key, instance, "finalizer.example.com", []func(){})
+	result, err := r.GetInstance(ctx, key, instance, nil, nil)
 	if result != nil || err != nil {
 		return *result, err
 	}

--- a/pkg/reconcilers/basereconciler/v2/test/test_controller_suite_test.go
+++ b/pkg/reconcilers/basereconciler/v2/test/test_controller_suite_test.go
@@ -62,12 +62,6 @@ var _ = Describe("Test controller", func() {
 
 		It("creates the required resources", func() {
 
-			Eventually(func() bool {
-				err := k8sClient.Get(context.Background(), types.NamespacedName{Name: "instance", Namespace: namespace}, instance)
-				Expect(err).ToNot(HaveOccurred())
-				return len(instance.GetFinalizers()) > 0
-			}, timeout, poll).Should(BeTrue())
-
 			dep := &appsv1.Deployment{}
 			Eventually(func() error {
 				return k8sClient.Get(
@@ -214,11 +208,6 @@ var _ = Describe("Test controller", func() {
 
 		It("Deletes all owned resources when custom resource is deleted", func() {
 			// Wait for all resources to be created
-			Eventually(func() bool {
-				err := k8sClient.Get(context.Background(), types.NamespacedName{Name: "instance", Namespace: namespace}, instance)
-				Expect(err).ToNot(HaveOccurred())
-				return len(instance.GetFinalizers()) > 0
-			}, timeout, poll).Should(BeTrue())
 
 			dep := &appsv1.Deployment{}
 			Eventually(func() error {
@@ -334,12 +323,6 @@ var _ = Describe("Test controller", func() {
 		})
 
 		It("creates the required deployment with proper labels and annotations", func() {
-
-			Eventually(func() bool {
-				err := k8sClient.Get(context.Background(), types.NamespacedName{Name: "instance", Namespace: namespace}, instance)
-				Expect(err).ToNot(HaveOccurred())
-				return len(instance.GetFinalizers()) > 0
-			}, timeout, poll).Should(BeTrue())
 
 			dep := &appsv1.Deployment{}
 			Eventually(func() error {

--- a/pkg/reconcilers/workloads/deployment_based_workload.go
+++ b/pkg/reconcilers/workloads/deployment_based_workload.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	basereconciler "github.com/3scale/saas-operator/pkg/reconcilers/basereconciler/v2"
-	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
@@ -16,12 +15,12 @@ type WorkloadReconciler struct {
 // NewFromManager constructs a new Reconciler from the given manager
 func NewFromManager(mgr manager.Manager, recorderName string, clusterWatchers bool) WorkloadReconciler {
 	return WorkloadReconciler{
-		Reconciler: basereconciler.NewFromManager(mgr, recorderName, clusterWatchers),
+		Reconciler: basereconciler.NewFromManager(mgr),
 	}
 }
 
 func (r *WorkloadReconciler) NewDeploymentWorkload(ctx context.Context, owner client.Object,
-	scheme *runtime.Scheme, workloads ...DeploymentWorkload) ([]basereconciler.Resource, error) {
+	workloads ...DeploymentWorkload) ([]basereconciler.Resource, error) {
 
 	resources := []basereconciler.Resource{}
 
@@ -38,7 +37,7 @@ func (r *WorkloadReconciler) NewDeploymentWorkload(ctx context.Context, owner cl
 }
 
 func (r *WorkloadReconciler) NewDeploymentWorkloadWithTraffic(ctx context.Context, owner client.Object,
-	scheme *runtime.Scheme, trafficManager TrafficManager, workloads ...DeploymentWorkloadWithTraffic) ([]basereconciler.Resource, error) {
+	trafficManager TrafficManager, workloads ...DeploymentWorkloadWithTraffic) ([]basereconciler.Resource, error) {
 
 	resources := []basereconciler.Resource{}
 

--- a/pkg/reconcilers/workloads/test/suite_test.go
+++ b/pkg/reconcilers/workloads/test/suite_test.go
@@ -22,6 +22,8 @@ import (
 	"testing"
 	"time"
 
+	saasv1alpha1 "github.com/3scale/saas-operator/api/v1alpha1"
+	externalsecretsv1beta1 "github.com/3scale/saas-operator/pkg/apis/externalsecrets/v1beta1"
 	grafanav1alpha1 "github.com/3scale/saas-operator/pkg/apis/grafana/v1alpha1"
 	"github.com/3scale/saas-operator/pkg/reconcilers/workloads"
 	"github.com/3scale/saas-operator/pkg/reconcilers/workloads/test/api/v1alpha1"
@@ -29,6 +31,7 @@ import (
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	monitoringv1 "github.com/prometheus-operator/prometheus-operator/pkg/apis/monitoring/v1"
+	utilruntime "k8s.io/apimachinery/pkg/util/runtime"
 	"k8s.io/client-go/kubernetes/scheme"
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -73,12 +76,11 @@ var _ = BeforeSuite(func() {
 	Expect(err).NotTo(HaveOccurred())
 	Expect(cfg).NotTo(BeNil())
 
-	err = v1alpha1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-	err = monitoringv1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
-	err = grafanav1alpha1.AddToScheme(scheme.Scheme)
-	Expect(err).NotTo(HaveOccurred())
+	utilruntime.Must(v1alpha1.AddToScheme(scheme.Scheme))
+	utilruntime.Must(saasv1alpha1.AddToScheme(scheme.Scheme))
+	utilruntime.Must(monitoringv1.AddToScheme(scheme.Scheme))
+	utilruntime.Must(grafanav1alpha1.AddToScheme(scheme.Scheme))
+	utilruntime.Must(externalsecretsv1beta1.AddToScheme(scheme.Scheme))
 
 	mgr, err := ctrl.NewManager(cfg, ctrl.Options{
 		Scheme: scheme.Scheme,

--- a/pkg/reconcilers/workloads/test/test_controller.go
+++ b/pkg/reconcilers/workloads/test/test_controller.go
@@ -55,7 +55,7 @@ func (r *Reconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Resu
 
 	instance := &v1alpha1.Test{}
 	key := types.NamespacedName{Name: req.Name, Namespace: req.Namespace}
-	result, err := r.GetInstance(ctx, key, instance, "finalizer.example.com", []func(){})
+	result, err := r.GetInstance(ctx, key, instance, nil, nil)
 	if result != nil || err != nil {
 		return *result, err
 	}

--- a/pkg/reconcilers/workloads/test/test_controller_suite_test.go
+++ b/pkg/reconcilers/workloads/test/test_controller_suite_test.go
@@ -72,12 +72,6 @@ var _ = Describe("Test controller", func() {
 
 		It("creates the required resources", func() {
 
-			Eventually(func() bool {
-				err := k8sClient.Get(context.Background(), types.NamespacedName{Name: "instance", Namespace: namespace}, instance)
-				Expect(err).ToNot(HaveOccurred())
-				return len(instance.GetFinalizers()) > 0
-			}, timeout, poll).Should(BeTrue())
-
 			// alice Deployment
 			{
 				alice := &appsv1.Deployment{}

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,7 +1,7 @@
 package version
 
 const (
-	version string = "v0.17.1-alpha.8"
+	version string = "v0.17.1-alpha.9"
 )
 
 // Current returns the current marin3r operator version

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,7 +1,7 @@
 package version
 
 const (
-	version string = "v0.17.1-alpha.9"
+	version string = "v0.17.1-alpha.11"
 )
 
 // Current returns the current marin3r operator version


### PR DESCRIPTION
Now that we have our own resource reconcilers for all the types that the operator manages, there is no need to keep the lockedresource reconciler code. This PR cleans that code.

/kind cleanup
/priority important-longterm
/assign

