### PR TITLE
Fix/System-console statefulset args

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 0.17.1-alpha.7
+VERSION ?= 0.17.1-alpha.8
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/bundle/manifests/saas-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/saas-operator.clusterserviceversion.yaml
@@ -574,7 +574,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/3scale/saas-operator
     support: Red Hat
-  name: saas-operator.v0.17.1-alpha.7
+  name: saas-operator.v0.17.1-alpha.8
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -4393,7 +4393,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
-                image: quay.io/3scale/saas-operator:v0.17.1-alpha.7
+                image: quay.io/3scale/saas-operator:v0.17.1-alpha.8
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -4895,4 +4895,4 @@ spec:
   provider:
     name: Red Hat
     url: https://www.3scale.net/
-  version: 0.17.1-alpha.7
+  version: 0.17.1-alpha.8

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,4 +13,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/3scale/saas-operator
-  newTag: v0.17.1-alpha.7
+  newTag: v0.17.1-alpha.8

--- a/pkg/generators/system/console_statefulset.go
+++ b/pkg/generators/system/console_statefulset.go
@@ -46,10 +46,12 @@ func (gen *ConsoleGenerator) statefulset() func() *appsv1.StatefulSet {
 						SecurityContext: &corev1.PodSecurityContext{},
 						Containers: []corev1.Container{
 							{
-								Name:                     strings.Join([]string{component, console}, "-"),
-								Image:                    fmt.Sprintf("%s:%s", *gen.Image.Name, *gen.Image.Tag),
-								Command:                  []string{"sleep"},
-								Args:                     []string{"infinity"},
+								Name:  strings.Join([]string{component, console}, "-"),
+								Image: fmt.Sprintf("%s:%s", *gen.Image.Name, *gen.Image.Tag),
+								Args: []string{
+									"sleep",
+									"infinity",
+								},
 								Env:                      pod.BuildEnvironment(gen.Options),
 								Ports:                    nil,
 								Resources:                corev1.ResourceRequirements(*gen.Spec.Resources),

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,7 +1,7 @@
 package version
 
 const (
-	version string = "v0.17.1-alpha.7"
+	version string = "v0.17.1-alpha.8"
 )
 
 // Current returns the current marin3r operator version


### PR DESCRIPTION
System-console statefulset was not loading correct system config fils due to the command used, and the one in 3scale/porta entrypoint.

In other system pods (exept console) the active merchant configuration is correctly set as `:test`.

However in system-console the "extra" config files are not applied, so apparently it uses the configuration that is built into the container.

In this case the settings.yml file misses active_merchant_mode, so it's "calculated" based on the Rails env, so ends up being `:production`.

The reason for this is that the whole config symlinking happens in the container image entrypoint: https://github.com/3scale/porta/blob/2028c613de09c73de06d7c31406478d967976e37/openshift/system/entrypoint.sh#L8-L21

And this is not used in system-console where the command is overridden by **sleep**

### system-app:
```
sh-4.2$ ls -al config
total 152
drwxrwsr-x. 1 default    root  4096 Nov 24 17:00 .
drwxrwxr-x. 1 default    root  4096 Nov 28 13:25 ..
drwxrwsr-x. 2 default    root   218 Oct 25 20:03 abilities
lrwxrwxrwx. 1 1000590000 root    39 Nov 24 17:00 amazon_s3.yml -> /opt/system-extra-configs/amazon_s3.yml
-rwxrwxr--. 1 default    root 13551 Oct 25 20:03 application.rb
lrwxrwxrwx. 1 1000590000 root    37 Nov 24 17:00 backend.yml -> /opt/system-extra-configs/backend.yml
lrwxrwxrwx. 1 1000590000 root    43 Nov 24 17:00 backend_redis.yml -> /opt/system-extra-configs/backend_redis.yml
lrwxrwxrwx. 1 1000590000 root    44 Nov 24 17:00 banned_domains.yml -> /opt/system-extra-configs/banned_domains.yml
```
### system-console (it is using the image files):
```
sh-4.2$ ls -al config
total 224
drwxrwsr-x. 11 default root  4096 Nov  7 11:00 .
drwxrwxr-x.  1 default root     6 Nov 28 12:46 ..
drwxrwsr-x.  2 default root   218 Oct 25 20:03 abilities
-rwxrwxr--.  1 default root   557 Oct 25 20:03 amazon_s3.yml
-rwxrwxr--.  1 default root 13551 Oct 25 20:03 application.rb
-rwxrwxr--.  1 default root   293 Oct 25 20:03 backend.yml
-rwxrwxr--.  1 default root   351 Oct 25 20:03 backend_redis.yml
-rwxrwxr--.  1 default root   128 Oct 25 20:03 boot.rb
```

This PR fixes the console container args.

 
/kind bug
/priority important-soon
/assign