### PR TITLE
Fix regression introduced by commit 8bc3e0d

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 0.17.1
+VERSION ?= 0.17.2
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/bundle/manifests/saas-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/saas-operator.clusterserviceversion.yaml
@@ -576,7 +576,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/3scale/saas-operator
     support: Red Hat
-  name: saas-operator.v0.17.1
+  name: saas-operator.v0.17.2
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -4401,7 +4401,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
-                image: quay.io/3scale/saas-operator:v0.17.1
+                image: quay.io/3scale/saas-operator:v0.17.2
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -4903,4 +4903,4 @@ spec:
   provider:
     name: Red Hat
     url: https://www.3scale.net/
-  version: 0.17.1
+  version: 0.17.2

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,4 +13,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/3scale/saas-operator
-  newTag: v0.17.1
+  newTag: v0.17.2

--- a/controllers/twemproxyconfig_controller.go
+++ b/controllers/twemproxyconfig_controller.go
@@ -38,7 +38,9 @@ import (
 	ctrl "sigs.k8s.io/controller-runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/controller/controllerutil"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/log"
+	"sigs.k8s.io/controller-runtime/pkg/source"
 )
 
 // TwemproxyConfigReconciler reconciles a TwemproxyConfig object
@@ -230,5 +232,6 @@ func (r *TwemproxyConfigReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&saasv1alpha1.TwemproxyConfig{}).
 		Owns(&corev1.ConfigMap{}).
 		Owns(&grafanav1alpha1.GrafanaDashboard{}).
+		Watches(&source.Channel{Source: r.SentinelEvents.GetChannel()}, &handler.EnqueueRequestForObject{}).
 		Complete(r)
 }

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,7 +1,7 @@
 package version
 
 const (
-	version string = "v0.17.1"
+	version string = "v0.17.2"
 )
 
 // Current returns the current marin3r operator version


### PR DESCRIPTION
Mistakenly, the watch for sentinel events was removed from the TwemproxyConfig controller with commit
8bc3e0d. This is hard to detect because it just makes the reconcile slower so the tests pass. This commit brings back the watch to speed up reconcile times for twemproxy configuration.

/kind bug
/priority critical-urgent
/assign