### PR TITLE
Fix randomization in parallel ginkgo test runs

### DIFF
--- a/controllers/suite_test.go
+++ b/controllers/suite_test.go
@@ -72,7 +72,7 @@ var _ = BeforeSuite(func() {
 		},
 	}
 
-	seed := time.Now().UTC().UnixNano()
+	seed := GinkgoRandomSeed() + int64(GinkgoParallelProcess())
 	nameGenerator = namegenerator.NewNameGenerator(seed)
 
 	cfg, err := testEnv.Start()

--- a/pkg/reconcilers/basereconciler/v2/test/suite_test.go
+++ b/pkg/reconcilers/basereconciler/v2/test/suite_test.go
@@ -72,7 +72,7 @@ var _ = BeforeSuite(func() {
 		},
 	}
 
-	seed := time.Now().UTC().UnixNano()
+	seed := GinkgoRandomSeed() + int64(GinkgoParallelProcess())
 	nameGenerator = namegenerator.NewNameGenerator(seed)
 
 	cfg, err := testEnv.Start()

--- a/pkg/reconcilers/workloads/test/suite_test.go
+++ b/pkg/reconcilers/workloads/test/suite_test.go
@@ -69,7 +69,8 @@ var _ = BeforeSuite(func() {
 			filepath.Join("..", "..", "..", "..", "config", "test", "external-apis"),
 		},
 	}
-	seed := time.Now().UTC().UnixNano()
+
+	seed := GinkgoRandomSeed() + int64(GinkgoParallelProcess())
 	nameGenerator = namegenerator.NewNameGenerator(seed)
 
 	cfg, err := testEnv.Start()

--- a/test/e2e/suite_test.go
+++ b/test/e2e/suite_test.go
@@ -59,7 +59,7 @@ func TestAPIs(t *testing.T) {
 var _ = BeforeSuite(func() {
 	logf.SetLogger(zap.New(zap.WriteTo(GinkgoWriter), zap.UseDevMode(true)))
 
-	seed := time.Now().UTC().UnixNano()
+	seed := GinkgoRandomSeed() + int64(GinkgoParallelProcess())
 	nameGenerator = namegenerator.NewNameGenerator(seed)
 
 	By("bootstrapping test environment")


### PR DESCRIPTION
GinkgoRandomSeed() is used by ginkgo to randomize certain aspects of a test run and it uses the timestamp. This alone does not fix the issue because the seed is the same for all parallel nodes, so we add to it with the parallel node identifier.

/kind bug
/priority important-longterm
/assign