### PR TITLE
Feat/Add sphinx batch size field to System CR

### DIFF
--- a/api/v1alpha1/system_types.go
+++ b/api/v1alpha1/system_types.go
@@ -160,6 +160,7 @@ var (
 	systemDefaultSphinxPort                int32                           = 9306
 	systemDefaultSphinxBindAddress         string                          = "0.0.0.0"
 	systemDefaultSphinxConfigFile          string                          = "/opt/system/db/sphinx/sphinx.conf"
+	systemDefaultSphinxBatchSize           int32                           = 100
 	systemDefaultSphinxDBPath              string                          = "/opt/system/db/sphinx"
 	systemDefaultSphinxDatabaseStorageSize string                          = "30Gi"
 	systemDefaultSphinxPIDFile             string                          = "/opt/system/tmp/pids/searchd.pid"
@@ -794,6 +795,10 @@ type ThinkingSpec struct {
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	// +optional
 	ConfigFile *string `json:"configFile,omitempty"`
+	// Sphinx batch size
+	// +operator-sdk:csv:customresourcedefinitions:type=spec
+	// +optional
+	BatchSize *int32 `json:"batchSize,omitempty"`
 	// Sphinx database path
 	// +operator-sdk:csv:customresourcedefinitions:type=spec
 	// +optional
@@ -817,6 +822,7 @@ func (tc *ThinkingSpec) Default() {
 	tc.Port = intOrDefault(tc.Port, pointer.Int32Ptr(systemDefaultSphinxPort))
 	tc.BindAddress = stringOrDefault(tc.BindAddress, pointer.StringPtr(systemDefaultSphinxBindAddress))
 	tc.ConfigFile = stringOrDefault(tc.ConfigFile, pointer.StringPtr(systemDefaultSphinxConfigFile))
+	tc.BatchSize = intOrDefault(tc.BatchSize, pointer.Int32Ptr(systemDefaultSphinxBatchSize))
 	tc.DatabasePath = stringOrDefault(tc.DatabasePath, pointer.StringPtr(systemDefaultSphinxDBPath))
 	tc.PIDFile = stringOrDefault(tc.PIDFile, pointer.StringPtr(systemDefaultSphinxPIDFile))
 	if tc.DatabaseStorageSize == nil {

--- a/api/v1alpha1/zz_generated.deepcopy.go
+++ b/api/v1alpha1/zz_generated.deepcopy.go
@@ -3153,6 +3153,11 @@ func (in *ThinkingSpec) DeepCopyInto(out *ThinkingSpec) {
 		*out = new(string)
 		**out = **in
 	}
+	if in.BatchSize != nil {
+		in, out := &in.BatchSize, &out.BatchSize
+		*out = new(int32)
+		**out = **in
+	}
 	if in.DatabasePath != nil {
 		in, out := &in.DatabasePath, &out.DatabasePath
 		*out = new(string)

--- a/bundle/manifests/saas-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/saas-operator.clusterserviceversion.yaml
@@ -3672,6 +3672,9 @@ spec:
       - description: Thinking configuration for sphinx
         displayName: Thinking
         path: sphinx.config.thinking
+      - description: Sphinx batch size
+        displayName: Batch Size
+        path: sphinx.config.thinking.batchSize
       - description: Allows setting the TCP host for Sphinx to a different address
         displayName: Bind Address
         path: sphinx.config.thinking.bindAddress

--- a/bundle/manifests/saas.3scale.net_apicasts.yaml
+++ b/bundle/manifests/saas.3scale.net_apicasts.yaml
@@ -240,8 +240,8 @@ spec:
                     properties:
                       dynamicConfigs:
                         additionalProperties:
-                          maxProperties: 1
-                          minProperties: 1
+                          maxProperties: 2
+                          minProperties: 2
                           properties:
                             cluster:
                               description: Cluster contains options for an Envoy cluster
@@ -1000,8 +1000,8 @@ spec:
                     properties:
                       dynamicConfigs:
                         additionalProperties:
-                          maxProperties: 1
-                          minProperties: 1
+                          maxProperties: 2
+                          minProperties: 2
                           properties:
                             cluster:
                               description: Cluster contains options for an Envoy cluster

--- a/bundle/manifests/saas.3scale.net_backends.yaml
+++ b/bundle/manifests/saas.3scale.net_backends.yaml
@@ -670,8 +670,8 @@ spec:
                     properties:
                       dynamicConfigs:
                         additionalProperties:
-                          maxProperties: 1
-                          minProperties: 1
+                          maxProperties: 2
+                          minProperties: 2
                           properties:
                             cluster:
                               description: Cluster contains options for an Envoy cluster

--- a/bundle/manifests/saas.3scale.net_echoapis.yaml
+++ b/bundle/manifests/saas.3scale.net_echoapis.yaml
@@ -138,8 +138,8 @@ spec:
                 properties:
                   dynamicConfigs:
                     additionalProperties:
-                      maxProperties: 1
-                      minProperties: 1
+                      maxProperties: 2
+                      minProperties: 2
                       properties:
                         cluster:
                           description: Cluster contains options for an Envoy cluster

--- a/bundle/manifests/saas.3scale.net_systems.yaml
+++ b/bundle/manifests/saas.3scale.net_systems.yaml
@@ -2792,6 +2792,10 @@ spec:
                       thinking:
                         description: Thinking configuration for sphinx
                         properties:
+                          batchSize:
+                            description: Sphinx batch size
+                            format: int32
+                            type: integer
                           bindAddress:
                             description: Allows setting the TCP host for Sphinx to
                               a different address

--- a/config/crd/bases/saas.3scale.net_apicasts.yaml
+++ b/config/crd/bases/saas.3scale.net_apicasts.yaml
@@ -241,8 +241,8 @@ spec:
                     properties:
                       dynamicConfigs:
                         additionalProperties:
-                          maxProperties: 1
-                          minProperties: 1
+                          maxProperties: 2
+                          minProperties: 2
                           properties:
                             cluster:
                               description: Cluster contains options for an Envoy cluster
@@ -1001,8 +1001,8 @@ spec:
                     properties:
                       dynamicConfigs:
                         additionalProperties:
-                          maxProperties: 1
-                          minProperties: 1
+                          maxProperties: 2
+                          minProperties: 2
                           properties:
                             cluster:
                               description: Cluster contains options for an Envoy cluster

--- a/config/crd/bases/saas.3scale.net_backends.yaml
+++ b/config/crd/bases/saas.3scale.net_backends.yaml
@@ -671,8 +671,8 @@ spec:
                     properties:
                       dynamicConfigs:
                         additionalProperties:
-                          maxProperties: 1
-                          minProperties: 1
+                          maxProperties: 2
+                          minProperties: 2
                           properties:
                             cluster:
                               description: Cluster contains options for an Envoy cluster

--- a/config/crd/bases/saas.3scale.net_echoapis.yaml
+++ b/config/crd/bases/saas.3scale.net_echoapis.yaml
@@ -139,8 +139,8 @@ spec:
                 properties:
                   dynamicConfigs:
                     additionalProperties:
-                      maxProperties: 1
-                      minProperties: 1
+                      maxProperties: 2
+                      minProperties: 2
                       properties:
                         cluster:
                           description: Cluster contains options for an Envoy cluster

--- a/config/crd/bases/saas.3scale.net_systems.yaml
+++ b/config/crd/bases/saas.3scale.net_systems.yaml
@@ -2793,6 +2793,10 @@ spec:
                       thinking:
                         description: Thinking configuration for sphinx
                         properties:
+                          batchSize:
+                            description: Sphinx batch size
+                            format: int32
+                            type: integer
                           bindAddress:
                             description: Allows setting the TCP host for Sphinx to
                               a different address

--- a/config/manifests/bases/saas-operator.clusterserviceversion.yaml
+++ b/config/manifests/bases/saas-operator.clusterserviceversion.yaml
@@ -3184,6 +3184,9 @@ spec:
       - description: Thinking configuration for sphinx
         displayName: Thinking
         path: sphinx.config.thinking
+      - description: Sphinx batch size
+        displayName: Batch Size
+        path: sphinx.config.thinking.batchSize
       - description: Allows setting the TCP host for Sphinx to a different address
         displayName: Bind Address
         path: sphinx.config.thinking.bindAddress

--- a/docs/api-reference/reference.asciidoc
+++ b/docs/api-reference/reference.asciidoc
@@ -1764,6 +1764,7 @@ ThinkingSpec configures the thinking library for sphinx
 | *`port`* __integer__ | The TCP port Sphinx will run its daemon on
 | *`bindAddress`* __string__ | Allows setting the TCP host for Sphinx to a different address
 | *`configFile`* __string__ | Sphinx configuration file path
+| *`batchSize`* __integer__ | Sphinx batch size
 | *`databasePath`* __string__ | Sphinx database path
 | *`databaseStorageSize`* __Quantity__ | Sphinx database storage size
 | *`databaseStorageClass`* __string__ | Sphinx database storage type

--- a/pkg/generators/system/config/sphinx_options.go
+++ b/pkg/generators/system/config/sphinx_options.go
@@ -13,6 +13,7 @@ type SphinxOptions struct {
 	SphinxPort              pod.EnvVarValue `env:"THINKING_SPHINX_PORT"`
 	SphinxPIDFile           pod.EnvVarValue `env:"THINKING_SPHINX_PID_FILE"`
 	SphinxConfigurationFile pod.EnvVarValue `env:"THINKING_SPHINX_CONFIGURATION_FILE"`
+	SphinxBatchSize         pod.EnvVarValue `env:"THINKING_SPHINX_BATCH_SIZE"`
 
 	RailsEnvironment pod.EnvVarValue `env:"RAILS_ENV"`
 	SecretKeyBase    pod.EnvVarValue `env:"SECRET_KEY_BASE"`
@@ -32,6 +33,7 @@ func NewSphinxOptions(spec saasv1alpha1.SystemSpec) SphinxOptions {
 		SphinxPort:              &pod.ClearTextValue{Value: fmt.Sprintf("%d", *spec.Sphinx.Config.Thinking.Port)},
 		SphinxPIDFile:           &pod.ClearTextValue{Value: *spec.Sphinx.Config.Thinking.PIDFile},
 		SphinxConfigurationFile: &pod.ClearTextValue{Value: *spec.Sphinx.Config.Thinking.ConfigFile},
+		SphinxBatchSize:         &pod.ClearTextValue{Value: fmt.Sprintf("%d", *spec.Sphinx.Config.Thinking.BatchSize)},
 		RailsEnvironment:        &pod.ClearTextValue{Value: *spec.Config.Rails.Environment},
 		SecretKeyBase:           &pod.ClearTextValue{Value: "dummy"}, // https://github.com/rails/rails/issues/32947
 		DatabaseURL:             &pod.SecretValue{Value: spec.Config.DatabaseDSN},


### PR DESCRIPTION
Following upstream https://github.com/3scale/porta/pull/3162

This PR adds the new sphinx envvar, whose default value for SaaS is `100` (unlike upstream value `1000`, which causes errors in SaaS).

This new field permit us to not have to mount system-config secret on sphinx (containing the sphinx config file), so we can use the sphinx config file from the builtin container, modifying its behavior with this envvar.

/kind feature
/priority important-soon
/assign