### PR TITLE
Fix/System-config secret hash trigger

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 0.18.0-alpha.8
+VERSION ?= 0.18.0-alpha.10
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/bundle/manifests/saas-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/saas-operator.clusterserviceversion.yaml
@@ -635,7 +635,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/3scale/saas-operator
     support: Red Hat
-  name: saas-operator.v0.18.0-alpha.8
+  name: saas-operator.v0.18.0-alpha.10
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -4307,7 +4307,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
-                image: quay.io/3scale/saas-operator:v0.18.0-alpha.8
+                image: quay.io/3scale/saas-operator:v0.18.0-alpha.10
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -4821,4 +4821,4 @@ spec:
   provider:
     name: Red Hat
     url: https://www.3scale.net/
-  version: 0.18.0-alpha.8
+  version: 0.18.0-alpha.10

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,4 +13,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/3scale/saas-operator
-  newTag: v0.18.0-alpha.8
+  newTag: v0.18.0-alpha.10

--- a/pkg/generators/system/generator.go
+++ b/pkg/generators/system/generator.go
@@ -326,11 +326,13 @@ func (gen *Generator) ExternalSecrets() []basereconciler.Resource {
 	return resources
 }
 
-func getSystemSecretsRolloutTriggers() []basereconciler_resources.RolloutTrigger {
+func getSystemSecretsRolloutTriggers(additionalSecrets ...string) []basereconciler_resources.RolloutTrigger {
 
 	triggers := []basereconciler_resources.RolloutTrigger{}
 
-	for _, secret := range getSystemSecrets() {
+	secrets := append(getSystemSecrets(), additionalSecrets...)
+
+	for _, secret := range secrets {
 		triggers = append(
 			triggers,
 			basereconciler_resources.RolloutTrigger{
@@ -375,7 +377,7 @@ func (gen *AppGenerator) TrafficSelector() map[string]string {
 func (gen *AppGenerator) Deployment() basereconciler_resources.DeploymentTemplate {
 	return basereconciler_resources.DeploymentTemplate{
 		Template:        gen.deployment(),
-		RolloutTriggers: getSystemSecretsRolloutTriggers(),
+		RolloutTriggers: getSystemSecretsRolloutTriggers(gen.ConfigFilesSecret),
 		EnforceReplicas: gen.Spec.HPA.IsDeactivated(),
 		IsEnabled:       true,
 	}
@@ -416,7 +418,7 @@ type SidekiqGenerator struct {
 func (gen *SidekiqGenerator) Deployment() basereconciler_resources.DeploymentTemplate {
 	return basereconciler_resources.DeploymentTemplate{
 		Template:        gen.deployment(),
-		RolloutTriggers: getSystemSecretsRolloutTriggers(),
+		RolloutTriggers: getSystemSecretsRolloutTriggers(gen.ConfigFilesSecret),
 		EnforceReplicas: gen.Spec.HPA.IsDeactivated(),
 		IsEnabled:       true,
 	}
@@ -488,7 +490,7 @@ type ConsoleGenerator struct {
 func (gen *ConsoleGenerator) StatefulSet() basereconciler_resources.StatefulSetTemplate {
 	return basereconciler_resources.StatefulSetTemplate{
 		Template:        gen.statefulset(),
-		RolloutTriggers: getSystemSecretsRolloutTriggers(),
+		RolloutTriggers: getSystemSecretsRolloutTriggers(gen.ConfigFilesSecret),
 		IsEnabled:       gen.Enabled,
 	}
 }

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,7 +1,7 @@
 package version
 
 const (
-	version string = "v0.18.0-alpha.8"
+	version string = "v0.18.0-alpha.10"
 )
 
 // Current returns the current marin3r operator version


### PR DESCRIPTION
- Adds the secret hash rollot trigger to system-config secret, which is defined on a CR field because it is managed externally to saas-operator, unlike the rest of the secrets that are managed as ExternalSecrets inside saas-operator
   - So right now, if there is a change on that external secret mounted on System saas-operator deployments/statefulsets (all except sphinx), a rollout will be automatically triggered so new created pods will load new secret values 
- Creates alpha release `v0.18.0-alpha.10` that has been tested successfully in staging:
```
      annotations:
        saas.3scale.net/system-recaptcha.secret-hash: 6fd87786b8
        saas.3scale.net/system-backend.secret-hash: 7d69d9698b
        saas.3scale.net/system-master-apicast.secret-hash: 68c799f75b
        saas.3scale.net/system-events-hook.secret-hash: 6b99695c69
        saas.3scale.net/stg-saas-system-config.secret-hash: 7f9955868b  ## THIS
        saas.3scale.net/system-zync.secret-hash: 85c5cc6498
        saas.3scale.net/system-smtp.secret-hash: 54d765bf5c
        saas.3scale.net/system-multitenant-assets-s3.secret-hash: 7959c58cdd
        saas.3scale.net/system-app.secret-hash: 7b87786f7d
        saas.3scale.net/system-database.secret-hash: 7886f9678f
```

/kind bug
/priority important-soon
/assign