### PR TITLE
fix/prune-resources

### DIFF
--- a/pkg/reconcilers/basereconciler/v2/reconciler_test.go
+++ b/pkg/reconcilers/basereconciler/v2/reconciler_test.go
@@ -1,0 +1,84 @@
+package basereconciler
+
+import (
+	"testing"
+
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+func Test_isManaged(t *testing.T) {
+	type args struct {
+		key     types.NamespacedName
+		kind    string
+		managed []corev1.ObjectReference
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "Returns true",
+			args: args{
+				key:  types.NamespacedName{Name: "system-recaptcha", Namespace: "ns"},
+				kind: "Secret",
+				managed: []corev1.ObjectReference{
+					{Namespace: "ns", Name: "system-recaptcha", Kind: "Secret"},
+					{Namespace: "ns", Name: "system-smtp", Kind: "Secret"},
+					{Namespace: "ns", Name: "system-zync", Kind: "Secret"},
+					{Namespace: "ns", Name: "system", Kind: "Secret"},
+					{Namespace: "ns", Name: "system-app", Kind: "Deployment"},
+					{Namespace: "ns", Name: "system-app", Kind: "ServiceAccount"},
+					{Namespace: "ns", Name: "system-app", Kind: "HorizontalPodAutoscaler"},
+					{Namespace: "ns", Name: "system-app", Kind: "PodDisruptionBudget"},
+					{Namespace: "ns", Name: "system-app", Kind: "PodMonitor"},
+				},
+			},
+			want: true,
+		},
+		{
+			name: "Returns false",
+			args: args{
+				key:  types.NamespacedName{Name: "system-recaptcha", Namespace: "ns"},
+				kind: "Secret",
+				managed: []corev1.ObjectReference{
+					{Namespace: "ns", Name: "system-smtp", Kind: "Secret"},
+					{Namespace: "ns", Name: "system-zync", Kind: "Secret"},
+					{Namespace: "ns", Name: "system", Kind: "Secret"},
+					{Namespace: "ns", Name: "system-app", Kind: "Deployment"},
+					{Namespace: "ns", Name: "system-app", Kind: "ServiceAccount"},
+					{Namespace: "ns", Name: "system-app", Kind: "HorizontalPodAutoscaler"},
+					{Namespace: "ns", Name: "system-app", Kind: "PodDisruptionBudget"},
+					{Namespace: "ns", Name: "system-app", Kind: "PodMonitor"},
+				},
+			},
+			want: false,
+		},
+		{
+			name: "Returns false",
+			args: args{
+				key:  types.NamespacedName{Name: "system-app", Namespace: "ns"},
+				kind: "Role",
+				managed: []corev1.ObjectReference{
+					{Namespace: "ns", Name: "system-smtp", Kind: "Secret"},
+					{Namespace: "ns", Name: "system-zync", Kind: "Secret"},
+					{Namespace: "ns", Name: "system", Kind: "Secret"},
+					{Namespace: "ns", Name: "system-app", Kind: "Deployment"},
+					{Namespace: "ns", Name: "system-app", Kind: "ServiceAccount"},
+					{Namespace: "ns", Name: "system-app", Kind: "HorizontalPodAutoscaler"},
+					{Namespace: "ns", Name: "system-app", Kind: "PodDisruptionBudget"},
+					{Namespace: "ns", Name: "system-app", Kind: "PodMonitor"},
+				},
+			},
+			want: false,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isManaged(tt.args.key, tt.args.kind, tt.args.managed); got != tt.want {
+				t.Errorf("isManaged() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
I realised that the prune resources function could be ambiguous and remove something that should not be removed because there can be resources with the same name but different type. This is not currently a bug because we only use the pruner to delete canary resources, which happen to be differently named to all the other managed resources. But I wanted to fix this to avoid it biting us  in the future.

/kind bug
/priority important-longterm
/assign