### PR TITLE
Fix client ip in envoy logs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 0.19.5
+VERSION ?= 0.19.6
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/bundle/manifests/saas-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/saas-operator.clusterserviceversion.yaml
@@ -627,7 +627,7 @@ metadata:
     capabilities: Basic Install
     categories: Integration & Delivery
     containerImage: quay.io/3scale/saas-operator
-    createdAt: "2023-04-19T10:33:46Z"
+    createdAt: "2023-04-28T10:01:10Z"
     description: |-
       The 3scale SaaS Operator creates and maintains a SaaS-ready deployment
       of the Red Hat 3scale API Management on OpenShift.
@@ -635,7 +635,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/3scale/saas-operator
     support: Red Hat
-  name: saas-operator.v0.19.5
+  name: saas-operator.v0.19.6
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -4339,7 +4339,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
-                image: quay.io/3scale/saas-operator:v0.19.5
+                image: quay.io/3scale/saas-operator:v0.19.6
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -4853,4 +4853,4 @@ spec:
   provider:
     name: Red Hat
     url: https://www.3scale.net/
-  version: 0.19.5
+  version: 0.19.6

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,4 +13,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/3scale/saas-operator
-  newTag: v0.19.5
+  newTag: v0.19.6

--- a/pkg/assets/bindata.go
+++ b/pkg/assets/bindata.go
@@ -101,7 +101,7 @@ func dashboardsApicastServicesJsonGtpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "dashboards/apicast-services.json.gtpl", size: 17460, mode: os.FileMode(436), modTime: time.Unix(1679645064, 0)}
+	info := bindataFileInfo{name: "dashboards/apicast-services.json.gtpl", size: 17460, mode: os.FileMode(420), modTime: time.Unix(1679676915, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -121,7 +121,7 @@ func dashboardsApicastJsonGtpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "dashboards/apicast.json.gtpl", size: 84552, mode: os.FileMode(436), modTime: time.Unix(1679645064, 0)}
+	info := bindataFileInfo{name: "dashboards/apicast.json.gtpl", size: 84552, mode: os.FileMode(420), modTime: time.Unix(1679676915, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -141,7 +141,7 @@ func dashboardsAutosslJsonGtpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "dashboards/autossl.json.gtpl", size: 59366, mode: os.FileMode(436), modTime: time.Unix(1679645064, 0)}
+	info := bindataFileInfo{name: "dashboards/autossl.json.gtpl", size: 59366, mode: os.FileMode(420), modTime: time.Unix(1679676915, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -161,7 +161,7 @@ func dashboardsBackendJsonGtpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "dashboards/backend.json.gtpl", size: 122812, mode: os.FileMode(436), modTime: time.Unix(1679645064, 0)}
+	info := bindataFileInfo{name: "dashboards/backend.json.gtpl", size: 122812, mode: os.FileMode(420), modTime: time.Unix(1679676915, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -181,7 +181,7 @@ func dashboardsCorsProxyJsonGtpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "dashboards/cors-proxy.json.gtpl", size: 78737, mode: os.FileMode(436), modTime: time.Unix(1679645064, 0)}
+	info := bindataFileInfo{name: "dashboards/cors-proxy.json.gtpl", size: 78737, mode: os.FileMode(420), modTime: time.Unix(1679676915, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -201,7 +201,7 @@ func dashboardsMappingServiceJsonGtpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "dashboards/mapping-service.json.gtpl", size: 70528, mode: os.FileMode(436), modTime: time.Unix(1679645064, 0)}
+	info := bindataFileInfo{name: "dashboards/mapping-service.json.gtpl", size: 70528, mode: os.FileMode(420), modTime: time.Unix(1679676915, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -221,7 +221,7 @@ func dashboardsRedisSentinelJsonGtpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "dashboards/redis-sentinel.json.gtpl", size: 131661, mode: os.FileMode(436), modTime: time.Unix(1679645064, 0)}
+	info := bindataFileInfo{name: "dashboards/redis-sentinel.json.gtpl", size: 131661, mode: os.FileMode(420), modTime: time.Unix(1679676915, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -241,7 +241,7 @@ func dashboardsSystemJsonGtpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "dashboards/system.json.gtpl", size: 81338, mode: os.FileMode(436), modTime: time.Unix(1679645064, 0)}
+	info := bindataFileInfo{name: "dashboards/system.json.gtpl", size: 81338, mode: os.FileMode(420), modTime: time.Unix(1679676915, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -261,7 +261,7 @@ func dashboardsTwemproxyJsonGtpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "dashboards/twemproxy.json.gtpl", size: 130875, mode: os.FileMode(436), modTime: time.Unix(1679645064, 0)}
+	info := bindataFileInfo{name: "dashboards/twemproxy.json.gtpl", size: 130875, mode: os.FileMode(420), modTime: time.Unix(1679676915, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }
@@ -281,7 +281,7 @@ func dashboardsZyncJsonGtpl() (*asset, error) {
 		return nil, err
 	}
 
-	info := bindataFileInfo{name: "dashboards/zync.json.gtpl", size: 70304, mode: os.FileMode(436), modTime: time.Unix(1679645064, 0)}
+	info := bindataFileInfo{name: "dashboards/zync.json.gtpl", size: 70304, mode: os.FileMode(420), modTime: time.Unix(1679676915, 0)}
 	a := &asset{bytes: bytes, info: info}
 	return a, nil
 }

--- a/pkg/resource_builders/envoyconfig/resource_test.go
+++ b/pkg/resource_builders/envoyconfig/resource_test.go
@@ -115,7 +115,7 @@ func TestNew(t *testing.T) {
                                             authority: '%REQ(:AUTHORITY)%'
                                             bytes_received: '%BYTES_RECEIVED%'
                                             bytes_sent: '%BYTES_SENT%'
-                                            client_ip: '%REQ(X-ENVOY-EXTERNAL-ADDRESS)%'
+                                            client_ip: '%DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT%'
                                             downstream_tls_cipher: '%DOWNSTREAM_TLS_CIPHER%'
                                             downstream_tls_version: '%DOWNSTREAM_TLS_VERSION%'
                                             duration: '%DURATION%'

--- a/pkg/resource_builders/envoyconfig/templates/listeners.go
+++ b/pkg/resource_builders/envoyconfig/templates/listeners.go
@@ -186,7 +186,7 @@ func AccessLogConfig_v1(name string, tls bool) []*envoy_config_accesslog_v3.Acce
 											"upstream_cluster":      structpb.NewStringValue("%UPSTREAM_CLUSTER%"),
 											"upstream_service_time": structpb.NewStringValue("%RESP(X-ENVOY-UPSTREAM-SERVICE-TIME)%"),
 											"user_agent":            structpb.NewStringValue("%REQ(USER-AGENT)%"),
-											"client_ip":             structpb.NewStringValue("%REQ(X-ENVOY-EXTERNAL-ADDRESS)%"),
+											"client_ip":             structpb.NewStringValue("%DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT%"),
 										}
 										if tls {
 											m["downstream_tls_cipher"] = structpb.NewStringValue("%DOWNSTREAM_TLS_CIPHER%")

--- a/pkg/resource_builders/envoyconfig/templates/listeners_test.go
+++ b/pkg/resource_builders/envoyconfig/templates/listeners_test.go
@@ -63,7 +63,7 @@ func TestListenerHTTP_v1(t *testing.T) {
                               authority: '%REQ(:AUTHORITY)%'
                               bytes_received: '%BYTES_RECEIVED%'
                               bytes_sent: '%BYTES_SENT%'
-                              client_ip: '%REQ(X-ENVOY-EXTERNAL-ADDRESS)%'
+                              client_ip: '%DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT%'
                               downstream_tls_cipher: '%DOWNSTREAM_TLS_CIPHER%'
                               downstream_tls_version: '%DOWNSTREAM_TLS_VERSION%'
                               duration: '%DURATION%'
@@ -170,7 +170,7 @@ func TestListenerHTTP_v1(t *testing.T) {
                               authority: '%REQ(:AUTHORITY)%'
                               bytes_received: '%BYTES_RECEIVED%'
                               bytes_sent: '%BYTES_SENT%'
-                              client_ip: '%REQ(X-ENVOY-EXTERNAL-ADDRESS)%'
+                              client_ip: '%DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT%'
                               duration: '%DURATION%'
                               listener: test
                               method: '%REQ(:METHOD)%'

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,7 +1,7 @@
 package version
 
 const (
-	version string = "v0.19.5"
+	version string = "v0.19.6"
 )
 
 // Current returns the current marin3r operator version


### PR DESCRIPTION
We were taking the remote address from the `X-ENVOY-EXTERNAL-ADDRESS` envoy header, which is not even added when http/1.0 requests are rejected, so the field was empty in the logs. Using the internal variable `DOWNSTREAM_REMOTE_ADDRESS_WITHOUT_PORT` fixes this and remote address is also logged for rejected requests.

/kind bug
/priority important-soon
/assign