### PR TITLE
Avoid failover delays in twemproxy reconfig when using master targets

### DIFF
--- a/controllers/sentinel_controller.go
+++ b/controllers/sentinel_controller.go
@@ -175,7 +175,8 @@ func (r *SentinelReconciler) reconcileStatus(ctx context.Context, instance *saas
 	// and rely on reconciles triggered by sentinel events to correct the situation.
 	masterError := &sharded.DiscoveryError_Master_SingleServerFailure{}
 	slaveError := &sharded.DiscoveryError_Slave_SingleServerFailure{}
-	if errors.As(merr, masterError) || errors.As(merr, slaveError) {
+	failoverInProgressError := &sharded.DiscoveryError_Slave_FailoverInProgress{}
+	if errors.As(merr, masterError) || errors.As(merr, slaveError) || errors.As(merr, failoverInProgressError) {
 		log.Error(merr, "DiscoveryError")
 	}
 

--- a/examples/backend/redis-v6/redis.yaml
+++ b/examples/backend/redis-v6/redis.yaml
@@ -4,7 +4,7 @@ metadata:
   name: shard01
 spec:
    image:
-     tag: 6.2.7-alpine
+     tag: 6.2.13-alpine
 ---
 apiVersion: saas.3scale.net/v1alpha1
 kind: RedisShard
@@ -12,7 +12,7 @@ metadata:
   name: shard02
 spec:
    image:
-     tag: 6.2.7-alpine
+     tag: 6.2.13-alpine
 
 ---
 apiVersion: saas.3scale.net/v1alpha1
@@ -22,4 +22,4 @@ metadata:
 spec:
   slaveCount: 0
   image:
-    tag: 6.2.7-alpine
+    tag: 6.2.13-alpine

--- a/examples/backend/redis-v6/sentinel.yaml
+++ b/examples/backend/redis-v6/sentinel.yaml
@@ -5,7 +5,7 @@ metadata:
 spec:
   replicas: 3
   image:
-    tag: 6.2.7-debian-11-r17
+    tag: 6.2.13-debian-11-r76
   config:
     monitoredShards:
       # DNS should not be used in production. DNS is

--- a/go.mod
+++ b/go.mod
@@ -3,7 +3,7 @@ module github.com/3scale/saas-operator
 go 1.20
 
 require (
-	github.com/3scale-ops/basereconciler v0.3.4
+	github.com/3scale-ops/basereconciler v0.3.5
 	github.com/3scale-ops/marin3r v0.12.2
 	github.com/MakeNowJust/heredoc v1.0.0
 	github.com/aws/aws-sdk-go-v2 v1.21.0

--- a/go.sum
+++ b/go.sum
@@ -35,8 +35,8 @@ contrib.go.opencensus.io/exporter/ocagent v0.7.1-0.20200907061046-05415f1de66d/g
 contrib.go.opencensus.io/exporter/prometheus v0.4.0 h1:0QfIkj9z/iVZgK31D9H9ohjjIDApI2GOPScCKwxedbs=
 contrib.go.opencensus.io/exporter/prometheus v0.4.0/go.mod h1:o7cosnyfuPVK0tB8q0QmaQNhGnptITnPQB+z1+qeFB0=
 dmitri.shuralyov.com/gpu/mtl v0.0.0-20190408044501-666a987793e9/go.mod h1:H6x//7gZCb22OMCxBHrMx7a5I7Hp++hsVxbQ4BYO7hU=
-github.com/3scale-ops/basereconciler v0.3.4 h1:KRA535+TNR0HCdGpxp/MwI9H2hPkTsIf0F+bo9ZqOFI=
-github.com/3scale-ops/basereconciler v0.3.4/go.mod h1:tPJ50gfzbDC52reWkDDaEHO1leuRx9JzqggwIRA+cL0=
+github.com/3scale-ops/basereconciler v0.3.5 h1:If2KDs6aOQ467Ja88bGFe2zkZy87AjXvXEWJDGwHbZs=
+github.com/3scale-ops/basereconciler v0.3.5/go.mod h1:xKM3TsE4qr4fiYCpKeodlcoJUruOpYsJ8M8Iz8FlEpg=
 github.com/3scale-ops/marin3r v0.12.2 h1:sU4N7RZ5AQzfejrfP0KgpagmL/XD8a5NdSIv1qvaAnU=
 github.com/3scale-ops/marin3r v0.12.2/go.mod h1:BOU7EFv58PgPMgKgJFDd4ingfBhH6KC2AGJoD7i9SaU=
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=

--- a/pkg/generators/twemproxyconfig/generator_test.go
+++ b/pkg/generators/twemproxyconfig/generator_test.go
@@ -93,9 +93,23 @@ func TestNewGenerator(t *testing.T) {
 							InjectError: func() error { return nil },
 						},
 						redis_client.FakeResponse{
+							// cmd: SentinelGetMasterAddrByName (shard0)
+							InjectResponse: func() interface{} {
+								return []string{"127.0.0.1", "1000"}
+							},
+							InjectError: func() error { return nil },
+						},
+						redis_client.FakeResponse{
 							// cmd: SentinelMaster (shard1)
 							InjectResponse: func() interface{} {
 								return &redis_client.SentinelMasterCmdResult{Name: "shard1", IP: "127.0.0.1", Port: 5000, Flags: "master"}
+							},
+							InjectError: func() error { return nil },
+						},
+						redis_client.FakeResponse{
+							// cmd: SentinelGetMasterAddrByName (shard1)
+							InjectResponse: func() interface{} {
+								return []string{"127.0.0.1", "5000"}
 							},
 							InjectError: func() error { return nil },
 						},
@@ -259,6 +273,13 @@ func TestNewGenerator(t *testing.T) {
 							InjectError: func() error { return nil },
 						},
 						redis_client.FakeResponse{
+							// cmd: SentinelGetMasterAddrByName (shard0)
+							InjectResponse: func() interface{} {
+								return []string{"127.0.0.1", "1000"}
+							},
+							InjectError: func() error { return nil },
+						},
+						redis_client.FakeResponse{
 							// cmd: SentinelSlaves (shard0)
 							InjectResponse: func() interface{} {
 								return []interface{}{
@@ -282,6 +303,13 @@ func TestNewGenerator(t *testing.T) {
 							// cmd: SentinelMaster (shard1)
 							InjectResponse: func() interface{} {
 								return &redis_client.SentinelMasterCmdResult{Name: "shard1", IP: "127.0.0.1", Port: 5000, Flags: "master"}
+							},
+							InjectError: func() error { return nil },
+						},
+						redis_client.FakeResponse{
+							// cmd: SentinelGetMasterAddrByName (shard1)
+							InjectResponse: func() interface{} {
+								return []string{"127.0.0.1", "5000"}
 							},
 							InjectError: func() error { return nil },
 						},
@@ -429,6 +457,13 @@ func TestNewGenerator(t *testing.T) {
 							InjectError: func() error { return nil },
 						},
 						redis_client.FakeResponse{
+							// cmd: SentinelGetMasterAddrByName (shard0)
+							InjectResponse: func() interface{} {
+								return []string{"127.0.0.1", "1000"}
+							},
+							InjectError: func() error { return nil },
+						},
+						redis_client.FakeResponse{
 							// cmd: SentinelSlaves (shard0)
 							InjectResponse: func() interface{} {
 								return []interface{}{
@@ -452,6 +487,13 @@ func TestNewGenerator(t *testing.T) {
 							// cmd: SentinelMaster (shard1)
 							InjectResponse: func() interface{} {
 								return &redis_client.SentinelMasterCmdResult{Name: "shard1", IP: "127.0.0.1", Port: 5000, Flags: "master"}
+							},
+							InjectError: func() error { return nil },
+						},
+						redis_client.FakeResponse{
+							// cmd: SentinelGetMasterAddrByName (shard1)
+							InjectResponse: func() interface{} {
+								return []string{"127.0.0.1", "5000"}
 							},
 							InjectError: func() error { return nil },
 						},
@@ -594,9 +636,23 @@ func TestNewGenerator(t *testing.T) {
 							InjectError: func() error { return nil },
 						},
 						redis_client.FakeResponse{
+							// cmd: SentinelGetMasterAddrByName (shard0)
+							InjectResponse: func() interface{} {
+								return []string{"127.0.0.1", "1000"}
+							},
+							InjectError: func() error { return nil },
+						},
+						redis_client.FakeResponse{
 							// cmd: SentinelMaster (shard1)
 							InjectResponse: func() interface{} {
 								return &redis_client.SentinelMasterCmdResult{Name: "shard1", IP: "127.0.0.1", Port: 5000, Flags: "master"}
+							},
+							InjectError: func() error { return nil },
+						},
+						redis_client.FakeResponse{
+							// cmd: SentinelGetMasterAddrByName (shard1)
+							InjectResponse: func() interface{} {
+								return []string{"127.0.0.1", "5000"}
 							},
 							InjectError: func() error { return nil },
 						},

--- a/pkg/redis/client/fake_client.go
+++ b/pkg/redis/client/fake_client.go
@@ -58,6 +58,11 @@ func (fc *FakeClient) SentinelMaster(ctx context.Context, shard string) (*Sentin
 	return rsp.InjectResponse().(*SentinelMasterCmdResult), rsp.InjectError()
 }
 
+func (fc *FakeClient) SentinelGetMasterAddrByName(ctx context.Context, shard string) ([]string, error) {
+	rsp := fc.pop()
+	return rsp.InjectResponse().([]string), rsp.InjectError()
+}
+
 func (fc *FakeClient) SentinelMasters(ctx context.Context) ([]interface{}, error) {
 	rsp := fc.pop()
 	return rsp.InjectResponse().([]interface{}), rsp.InjectError()

--- a/pkg/redis/client/goredis_client.go
+++ b/pkg/redis/client/goredis_client.go
@@ -73,6 +73,12 @@ func (c *GoRedisClient) SentinelMaster(ctx context.Context, shard string) (*Sent
 	return result, err
 }
 
+func (c *GoRedisClient) SentinelGetMasterAddrByName(ctx context.Context, shard string) ([]string, error) {
+
+	values, err := c.sentinel.GetMasterAddrByName(ctx, shard).Result()
+	return values, err
+}
+
 func (c *GoRedisClient) SentinelMasters(ctx context.Context) ([]interface{}, error) {
 
 	values, err := c.sentinel.Masters(ctx).Result()

--- a/pkg/redis/client/interface.go
+++ b/pkg/redis/client/interface.go
@@ -13,6 +13,7 @@ import (
 type TestableInterface interface {
 	SentinelMaster(context.Context, string) (*SentinelMasterCmdResult, error)
 	SentinelMasters(context.Context) ([]interface{}, error)
+	SentinelGetMasterAddrByName(ctx context.Context, shard string) ([]string, error)
 	SentinelSlaves(context.Context, string) ([]interface{}, error)
 	SentinelMonitor(context.Context, string, string, string, int) error
 	SentinelSet(context.Context, string, string, string) error

--- a/pkg/redis/server/server.go
+++ b/pkg/redis/server/server.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"context"
 	"net"
+	"strconv"
 	"strings"
 	"sync"
 	"time"
@@ -107,6 +108,19 @@ func (srv *Server) SentinelMaster(ctx context.Context, shard string) (*client.Se
 		return nil, err
 	}
 	return result, nil
+}
+
+func (srv *Server) SentinelGetMasterAddrByName(ctx context.Context, shard string) (string, int, error) {
+
+	values, err := srv.client.SentinelGetMasterAddrByName(ctx, shard)
+	if err != nil {
+		return "", 0, err
+	}
+	port, err := strconv.Atoi(values[1])
+	if err != nil {
+		return "", 0, err
+	}
+	return values[0], port, nil
 }
 
 func (srv *Server) SentinelMasters(ctx context.Context) ([]client.SentinelMasterCmdResult, error) {

--- a/pkg/redis/sharded/discover.go
+++ b/pkg/redis/sharded/discover.go
@@ -105,5 +105,6 @@ func (srv *RedisServer) Discover(ctx context.Context, opts ...DiscoveryOption) e
 // Discovery errors
 type DiscoveryError_Sentinel_Failure struct{ error }
 type DiscoveryError_Master_SingleServerFailure struct{ error }
+type DiscoveryError_Slave_FailoverInProgress struct{ error }
 type DiscoveryError_Slave_SingleServerFailure struct{ error }
 type DiscoveryError_UnknownRole_SingleServerFailure struct{ error }

--- a/pkg/redis/sharded/redis_sharded_cluster_test.go
+++ b/pkg/redis/sharded/redis_sharded_cluster_test.go
@@ -457,6 +457,13 @@ func TestCluster_SentinelDiscover(t *testing.T) {
 							InjectError: func() error { return nil },
 						},
 						client.FakeResponse{
+							// cmd: SentinelGetMasterAddrByName (shard0)
+							InjectResponse: func() interface{} {
+								return []string{"127.0.0.1", "1000"}
+							},
+							InjectError: func() error { return nil },
+						},
+						client.FakeResponse{
 							// cmd: SentinelSlaves (shard0)
 							InjectResponse: func() interface{} {
 								return []interface{}{
@@ -480,6 +487,13 @@ func TestCluster_SentinelDiscover(t *testing.T) {
 							// cmd: SentinelMaster (shard1)
 							InjectResponse: func() interface{} {
 								return &client.SentinelMasterCmdResult{Name: "shard1", IP: "127.0.0.1", Port: 5000, Flags: "master"}
+							},
+							InjectError: func() error { return nil },
+						},
+						client.FakeResponse{
+							// cmd: SentinelGetMasterAddrByName (shard1)
+							InjectResponse: func() interface{} {
+								return []string{"127.0.0.1", "5000"}
 							},
 							InjectError: func() error { return nil },
 						},
@@ -549,6 +563,13 @@ func TestCluster_SentinelDiscover(t *testing.T) {
 							InjectError: func() error { return nil },
 						},
 						client.FakeResponse{
+							// cmd: SentinelGetMasterAddrByName (shard0)
+							InjectResponse: func() interface{} {
+								return []string{"127.0.0.1", "1000"}
+							},
+							InjectError: func() error { return nil },
+						},
+						client.FakeResponse{
 							// cmd: SentinelSlaves (shard0)
 							InjectResponse: func() interface{} {
 								return []interface{}{
@@ -572,6 +593,13 @@ func TestCluster_SentinelDiscover(t *testing.T) {
 							// cmd: SentinelMaster (shard1)
 							InjectResponse: func() interface{} {
 								return &client.SentinelMasterCmdResult{Name: "shard1", IP: "127.0.0.1", Port: 5000, Flags: "master"}
+							},
+							InjectError: func() error { return nil },
+						},
+						client.FakeResponse{
+							// cmd: SentinelGetMasterAddrByName (shard1)
+							InjectResponse: func() interface{} {
+								return []string{"127.0.0.1", "5000"}
 							},
 							InjectError: func() error { return nil },
 						},
@@ -671,6 +699,13 @@ func TestCluster_SentinelDiscover(t *testing.T) {
 							// cmd: SentinelMaster (shard0)
 							InjectResponse: func() interface{} {
 								return &client.SentinelMasterCmdResult{Name: "shard0", IP: "127.0.0.1", Port: 1000, Flags: "master"}
+							},
+							InjectError: func() error { return nil },
+						},
+						client.FakeResponse{
+							// cmd: SentinelGetMasterAddrByName (shard0)
+							InjectResponse: func() interface{} {
+								return []string{"127.0.0.1", "1000"}
 							},
 							InjectError: func() error { return nil },
 						},


### PR DESCRIPTION
It seems that even though the "sentinel master <shard_name>" command returns updated information about the master as soon as a slave is promoted, there is an exception with the sentinel instance that acts as "failover leader". The failover leader is the instance that actually performs the shard reconfigurations, and in this case, its "sentinel master <shard_name>" command only returns updated information when all the slaves have been also reconfigured to point to the new master. This causes delays in twemproxy reconfiguration if this is the instance used by the twemproxyconfig controller to "discover" the shard.
To detect this situation, add a step that checks the master address with the command "sentinel get-master-addr-by-name <shard_name>". This command always returns updated master information, even if we are querying the leader sentinel instance.

This must be merged before #276 as it should be included in the new release.

/kind bug
/priority important-soon
/assign