### PR TITLE
Fix/Sentinel switch-master-count metric

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 0.20.1
+VERSION ?= 0.20.2
 
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")

--- a/bundle/manifests/saas-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/saas-operator.clusterserviceversion.yaml
@@ -657,7 +657,7 @@ metadata:
     capabilities: Basic Install
     categories: Integration & Delivery
     containerImage: quay.io/3scale/saas-operator
-    createdAt: "2023-10-25T15:22:33Z"
+    createdAt: "2023-11-16T11:11:43Z"
     description: |-
       The 3scale SaaS Operator creates and maintains a SaaS-ready deployment
       of the Red Hat 3scale API Management on OpenShift.
@@ -665,7 +665,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/3scale/saas-operator
     support: Red Hat
-  name: saas-operator.v0.20.1
+  name: saas-operator.v0.20.2
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -4540,7 +4540,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
-                image: quay.io/3scale/saas-operator:v0.20.1
+                image: quay.io/3scale/saas-operator:v0.20.2
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -5104,4 +5104,4 @@ spec:
   provider:
     name: Red Hat
     url: https://www.3scale.net/
-  version: 0.20.1
+  version: 0.20.2

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,4 +13,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/3scale/saas-operator
-  newTag: v0.20.1
+  newTag: v0.20.2

--- a/pkg/redis/events/watcher.go
+++ b/pkg/redis/events/watcher.go
@@ -21,7 +21,7 @@ var (
 			Namespace: "saas_redis_sentinel",
 			Help:      "+switch-master (https://redis.io/topics/sentinel#sentinel-api)",
 		},
-		[]string{"sentinel", "shard", "redis_server"},
+		[]string{"sentinel", "shard"},
 	)
 
 	failoverAbortNoGoodSlaveCount = prometheus.NewCounterVec(
@@ -194,7 +194,6 @@ func (sew *SentinelEventWatcher) metricsFromEvent(rem RedisEventMessage) {
 		switchMasterCount.With(
 			prometheus.Labels{
 				"sentinel": sew.sentinelURI, "shard": rem.master.name,
-				"redis_server": fmt.Sprintf("%s:%s", rem.master.ip, rem.master.port),
 			},
 		).Add(1)
 	case "-failover-abort-no-good-slave":
@@ -254,7 +253,6 @@ func (sew *SentinelEventWatcher) initCounters() {
 				switchMasterCount.With(
 					prometheus.Labels{
 						"sentinel": sew.sentinelURI, "shard": shard.Name,
-						"redis_server": server.ID(),
 					},
 				).Add(0)
 				sdownSentinelCount.With(

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,7 +1,7 @@
 package version
 
 const (
-	version string = "v0.20.1"
+	version string = "v0.20.2"
 )
 
 // Current returns the current marin3r operator version


### PR DESCRIPTION
With recent migrations we saw that failover alert do not work on the first failover upon saas-operator pod creation.

The reason is, there is a timeseries database for every `redis_server`, on latest migrations the failover orcurs on a new redis server instance, passing the counter from `non-exist` to `1`, so prometheus `rate` does not get it.

In the next image, filtering per shard and sentinel, there are 3 timeseriesdb with `0` value (the ones from old redis_servers), and one timeseriesdb with value `1` (new redis_server).
![image](https://github.com/3scale-ops/saas-operator/assets/41513123/2077b45d-c36a-4d81-bea5-5cfa7b6f116c)

This PR removes the `redis_server` label from **switchMasterCount** metric, the same already done at **failoverAbortNoGoodSlaveCount**, which is the same case, we want a metric per shard only.

/kind bug
/kind release
/priority important-soon
/assign