### PR TITLE
Cleanup/Finally remove system deprecated BACKEND_ROUTE envvar

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 # To re-generate a bundle for another specific version without changing the standard setup, you can:
 # - use the VERSION as arg of the bundle target (e.g make bundle VERSION=0.0.2)
 # - use environment variables to overwrite this value (e.g export VERSION=0.0.2)
-VERSION ?= 0.22.0-alpha.3
+VERSION ?= 0.22.0-alpha.4
 # CHANNELS define the bundle channels used in the bundle.
 # Add a new line here if you would like to change its default config. (E.g CHANNELS = "candidate,fast,stable")
 # To re-generate a bundle for other specific channels without changing the standard setup, you can:

--- a/bundle/manifests/saas-operator.clusterserviceversion.yaml
+++ b/bundle/manifests/saas-operator.clusterserviceversion.yaml
@@ -598,7 +598,7 @@ metadata:
     capabilities: Basic Install
     categories: Integration & Delivery
     containerImage: quay.io/3scale/saas-operator
-    createdAt: "2024-01-22T16:11:08Z"
+    createdAt: "2024-01-23T11:19:58Z"
     description: |-
       The 3scale SaaS Operator creates and maintains a SaaS-ready deployment
       of the Red Hat 3scale API Management on OpenShift.
@@ -606,7 +606,7 @@ metadata:
     operators.operatorframework.io/project_layout: go.kubebuilder.io/v3
     repository: https://github.com/3scale-ops/saas-operator
     support: Red Hat
-  name: saas-operator.v0.22.0-alpha.3
+  name: saas-operator.v0.22.0-alpha.4
   namespace: placeholder
 spec:
   apiservicedefinitions: {}
@@ -4468,7 +4468,7 @@ spec:
                   valueFrom:
                     fieldRef:
                       fieldPath: metadata.annotations['olm.targetNamespaces']
-                image: quay.io/3scale/saas-operator:v0.22.0-alpha.3
+                image: quay.io/3scale/saas-operator:v0.22.0-alpha.4
                 livenessProbe:
                   httpGet:
                     path: /healthz
@@ -5032,4 +5032,4 @@ spec:
   provider:
     name: Red Hat
     url: https://www.3scale.net/
-  version: 0.22.0-alpha.3
+  version: 0.22.0-alpha.4

--- a/config/manager/kustomization.yaml
+++ b/config/manager/kustomization.yaml
@@ -13,4 +13,4 @@ kind: Kustomization
 images:
 - name: controller
   newName: quay.io/3scale/saas-operator
-  newTag: v0.22.0-alpha.3
+  newTag: v0.22.0-alpha.4

--- a/pkg/generators/system/config/options.go
+++ b/pkg/generators/system/config/options.go
@@ -53,7 +53,6 @@ func NewOptions(spec saasv1alpha1.SystemSpec) pod.Options {
 	opts.Unpack(spec.Config.Backend.RedisDSN).IntoEnvvar("BACKEND_REDIS_URL")
 	opts.Unpack("").IntoEnvvar("BACKEND_REDIS_SENTINEL_HOSTS")
 	opts.Unpack("").IntoEnvvar("BACKEND_REDIS_SENTINEL_ROLE")
-	opts.Unpack(spec.Config.Backend.InternalEndpoint).IntoEnvvar("BACKEND_ROUTE") // DEPRECATED
 	opts.Unpack(spec.Config.Backend.InternalEndpoint).IntoEnvvar("BACKEND_URL")
 	opts.Unpack(spec.Config.Backend.ExternalEndpoint).IntoEnvvar("BACKEND_PUBLIC_URL")
 	opts.Unpack(spec.Config.Backend.InternalAPIUser).IntoEnvvar("CONFIG_INTERNAL_API_USER").AsSecretRef("system-backend")

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,7 +1,7 @@
 package version
 
 const (
-	version string = "v0.22.0-alpha.3"
+	version string = "v0.22.0-alpha.4"
 )
 
 // Current returns the current marin3r operator version


### PR DESCRIPTION
On https://github.com/3scale/3scale-saas/pull/598 it was added the envvar `BACKEND_URL` which eventually would replace `BACKEND_ROUTE`

Those changes were already deployed in production, as well as the config file change at https://github.com/3scale/3scale-saas/pull/747

So now it is safe to finally remove the deprecated envvar.

/kind cleanup
/priority important-soon
/assign